### PR TITLE
fatal error for nonreadable files

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ EXAMPLES
 
      easy-manage-deposit report full someUserId
      easy-manage-deposit report summary someUserId
-     easy-manage-deposit report full someUserId
-     easy-manage-deposit report summary someUserId
+     easy-manage-deposit report full 
+     easy-manage-deposit report summary 
      easy-manage-deposit clean someUserId
      easy-manage-deposit clean --data-only --state <state> --keep <n> someUserId
      easy-manage-deposit retry someUserId

--- a/pom.xml
+++ b/pom.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
-    Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-
--->
+ 
+ Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ 
+ -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -32,7 +32,7 @@
     <description>Manages the deposits in the deposit area.</description>
     <inceptionYear>2017</inceptionYear>
     <properties>
-        <main-class>nl.knaw.dans.easy.report.Command</main-class>
+        <main-class>nl.knaw.dans.easy.managedeposit.Command</main-class>
     </properties>
     <scm>
         <developerConnection>scm:git:https://github.com/DANS-KNAW/easy-manage-deposit</developerConnection>
@@ -210,3 +210,4 @@
         </profile>
     </profiles>
 </project>
+

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
@@ -45,16 +45,36 @@ object Command extends App with DebugEnhancedLogging {
 
   val result: Try[FeedBackMessage] = commandLine.subcommands match {
     case commandLine.reportCmd :: (full @ commandLine.reportCmd.fullCmd) :: Nil =>
-      app.createFullReport(full.depositor.toOption)
+      app.collectDataNbrOfNonReadable(full.depositor.toOption)
+      if (app.nbrOfNonreadableCollectDataFromDepositors == 0) {
+        app.createFullReport(full.depositor.toOption)
+      }
+      else Failure(new Exception("a number of " + app.nbrOfNonreadableCollectDataFromDepositors + " files or directories were not readable: " + "\n" + app.out.toString))
+
     case commandLine.reportCmd :: (summary @ commandLine.reportCmd.summaryCmd) :: Nil =>
-      app.summary(summary.depositor.toOption)
+      app.collectDataNbrOfNonReadable(summary.depositor.toOption)
+      if (app.nbrOfNonreadableCollectDataFromDepositors == 0) {
+        app.summary(summary.depositor.toOption)
+      }
+      else Failure(new Exception("a number of " + app.nbrOfNonreadableCollectDataFromDepositors + " files or directories were not readable: " + "\n" + app.out.toString))
+
     case (clean @ commandLine.cleanCmd) :: Nil =>
-      if (cleanInteraction)
-        app.cleanDepositor(clean.depositor.toOption, clean.keep(), clean.state(), clean.dataOnly())
-      else
-        Try { "Clean operation aborted by user" }
+      app.cleanDepositorNbrOfNonReadable(clean.depositor.toOption, clean.keep(), clean.state(), clean.dataOnly())
+      if (app.nbrOfNonreadableDeleteDepositFromDepositsDir == 0) {
+        if (cleanInteraction)
+          app.cleanDepositor(clean.depositor.toOption, clean.keep(), clean.state(), clean.dataOnly())
+        else
+          Try { "Clean operation aborted by user" }
+      }
+      else Failure(new Exception("a number of " + app.nbrOfNonreadableDeleteDepositFromDepositsDir + " files or directories were not readable: " + "\n" + app.out.toString))
+
     case (retry @ commandLine.retryCmd) :: Nil =>
-      app.retryDepositor(retry.depositor.toOption)
+      app.retryDepositorNbrOfNonReadable(retry.depositor.toOption)
+      if (app.nbrOfNonreadableRetryStalledDeposit == 0) {
+        app.retryDepositor(retry.depositor.toOption)
+      }
+      else Failure(new Exception("a number of " + app.nbrOfNonreadableRetryStalledDeposit + " files or directories were not readable: " + "\n" + app.out.toString))
+
     case _ => Failure(new IllegalArgumentException("Enter a valid subcommand"))
   }
 


### PR DESCRIPTION
Fixes EASY-1417 and two NO JIRA issues

- [x] Done

#### When applied it will
* exit with a fatal error when there are nonreadable files and provide a message like: (EASY-1417)
ERROR: Exception: a number of 45 files or directories were not readable:
ERROR: cannot read path of file or directory
ERROR: cannot read path of file or directory
ERROR: cannot read path of file or directory
ERROR: cannot read path of file or directory
...
...
* repair the pom file (NO JIRA)
* find the actual path of metadata/dataset.xml (NO JIRA)
There were some nonreadable files not because of access rights but a wrong path since bagDir.resolve("metadata/dataset.xml") does not provide the correct path in some datasets.
Example: ./data/easy-sword2/27a0f545-12bf-4e3a-ba14-575f710387fe/pan-deposit-001/bag/metadata/dataset.xml. Like this one, there are several cases where the metadata directory is not directly under the bag directory. Thus, I used the following FileUtils function to find the real path of dataset.xml which is named as pathOfDatasetXml:
FileUtils.listFilesAndDirs(bagDir.toRealPath().toFile, TrueFileFilter.TRUE, TrueFileFilter.TRUE).forEach(
i => if (i.toString.contains("metadata/dataset.xml"))
pathOfDatasetXml = i.toPath
)

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
