### PR TITLE
EASY-1482: add extra age parameter for full and summary reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ SYNOPSIS
 --------
    
      easy-manage-deposit report full [--age, -a <n>] [<depositor>]
-     easy-manage-deposit report summary [--age|-a <n>] [<depositor>]
-     easy-manage-deposit clean [--data-only|-d] [--state|-s <state>] [--keep|-k <n>] [<depositor>]
+     easy-manage-deposit report summary [--age, -a <n>] [<depositor>]
+     easy-manage-deposit clean [--data-only, -d] [--state, -s <state>] [--keep, -k <n>] [<depositor>]
      easy-manage-deposit retry [<depositor>]
      
          

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ EXAMPLES
 
      easy-manage-deposit report full someUserId
      easy-manage-deposit report summary someUserId
-     easy-manage-deposit report full someUserId
-     easy-manage-deposit report summary someUserId
+     easy-manage-deposit report full -a 0 someUserId
+     easy-manage-deposit report summary --age 2 someUserId
      easy-manage-deposit clean someUserId
      easy-manage-deposit clean --data-only --state <state> --keep <n> someUserId
      easy-manage-deposit retry someUserId

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ SYNOPSIS
    
      easy-manage-deposit report full [{--age|-a} <n>] [<depositor>]
      easy-manage-deposit report summary [{--age|-a} <n>] [<depositor>]
-     easy-manage-deposit clean [{--data-only}] [{--state} <state>] [{--keep} <n>] [<depositor>]
+     easy-manage-deposit clean [{--data-only|-d}] [{--state|-s} <state>] [{--keep|-k} <n>] [<depositor>]
      easy-manage-deposit retry [<depositor>]
      
          

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ easy-manage-deposit
 SYNOPSIS
 --------
    
-     easy-manage-deposit report full [<depositor>]
-     easy-manage-deposit report summary [<depositor>]
-     easy-manage-deposit clean --data-only --state [<state>] --keep [<n>][<depositor>]
+     easy-manage-deposit report full [{--age|-a} <n>] [<depositor>]
+     easy-manage-deposit report summary [{--age|-a} <n>] [<depositor>]
+     easy-manage-deposit clean [{--data-only}] [{--state} <state>] [{--keep} <n>] [<depositor>]
      easy-manage-deposit retry [<depositor>]
      
          
@@ -20,43 +20,49 @@ ARGUMENTS
                 --version   Show version of this program
         
           Subcommand: report
-                  --help   Show help message
+                --help   Show help message
           
-            Subcommand: report full - creates a full report for depositor(optional)
-                  --help   Show help message
+          Subcommand: report full - creates a full report for depositor(optional)
+            -a, --age  <arg>   Only report on the deposits that are less than n days old.
+                               An age argument of n=0 days corresponds to 0<=n<1. If this
+                               argument is nog provided, all deposits will be reported on.
+                --help         Show help message
           
-             trailing arguments:
-              depositor (not required)
-            ---
+           trailing arguments:
+            depositor (not required)
+          ---
           
-            Subcommand: report summary - creates a summary report for depositor(optional)
-                  --help   Show help message
+          Subcommand: report summary - creates a summary report for depositor(optional)
+            -a, --age  <arg>   Only report on the deposits that are less than n days old.
+                               An age argument of n=0 days corresponds to 0<=n<1. If this
+                               argument is nog provided, all deposits will be reported on.
+                --help         Show help message
           
-             trailing arguments:
-              depositor (not required)
-            ---
-            Subcommand: clean
-              -d, --data-only      If specified, the deposit.properties and the container
-                                   file of the deposit are not deleted
-              -k, --keep  <arg>    The deposits whose ages are strictly greater than the
-                                   argument n (days) are deleted. An age argument of n=0
-                                   days corresponds to 0<=n<1. The default case is set to
-                                   n=-1, so that the deposits that are younger than 1 day
-                                   are not skipped in the default case. (default = -1)
-              -s, --state  <arg>   The deposits with the specified state argument are
-                                   deleted (default = DRAFT)
-                  --help           Show help message
+           trailing arguments:
+            depositor (not required)
+          ---
+          Subcommand: clean
+            -d, --data-only      If specified, the deposit.properties and the container
+                                 file of the deposit are not deleted
+            -k, --keep  <arg>    The deposits whose ages are strictly greater than the
+                                 argument n (days) are deleted. An age argument of n=0
+                                 days corresponds to 0<=n<1. The default case is set to
+                                 n=-1, so that the deposits that are younger than 1 day
+                                 are not skipped in the default case. (default = -1)
+            -s, --state  <arg>   The deposits with the specified state argument are
+                                 deleted (default = DRAFT)
+                --help           Show help message
           
-             trailing arguments:
-              depositor (not required)
-            ---
+           trailing arguments:
+            depositor (not required)
+          ---
           
-            Subcommand: retry
-                  --help   Show help message
+          Subcommand: retry
+                --help   Show help message
           
-             trailing arguments:
-              depositor (not required)
-     ---
+           trailing arguments:
+            depositor (not required)
+          ---
     
      
 DESCRIPTION

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ easy-manage-deposit
 SYNOPSIS
 --------
    
-     easy-manage-deposit report full [--age, -a <n>] [<depositor>]
-     easy-manage-deposit report summary [--age, -a <n>] [<depositor>]
-     easy-manage-deposit clean [--data-only, -d] [--state, -s <state>] [--keep, -k <n>] [<depositor>]
+     easy-manage-deposit report full [-a, --age <n>] [<depositor>]
+     easy-manage-deposit report summary [-a, --age <n>] [<depositor>]
+     easy-manage-deposit clean [-d, --data-only] [-s, --state <state>] [-k, --keep <n>] [<depositor>]
      easy-manage-deposit retry [<depositor>]
      
          

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ easy-manage-deposit
 SYNOPSIS
 --------
    
-     easy-manage-deposit report full [{--age|-a} <n>] [<depositor>]
-     easy-manage-deposit report summary [{--age|-a} <n>] [<depositor>]
-     easy-manage-deposit clean [{--data-only|-d}] [{--state|-s} <state>] [{--keep|-k} <n>] [<depositor>]
+     easy-manage-deposit report full [--age, -a <n>] [<depositor>]
+     easy-manage-deposit report summary [--age|-a <n>] [<depositor>]
+     easy-manage-deposit clean [--data-only|-d] [--state|-s <state>] [--keep|-k <n>] [<depositor>]
      easy-manage-deposit retry [<depositor>]
      
          

--- a/src/main/assembly/dist/bin/create-and-send-report.sh
+++ b/src/main/assembly/dist/bin/create-and-send-report.sh
@@ -20,7 +20,9 @@ fi
 
 DATE=$(date +%Y-%m-%d)
 REPORT_SUMMARY=/tmp/report-summary-${EASY_ACCOUNT:-all}-$DATE.txt
+REPORT_SUMMARY_24=/tmp/report-summary-${EASY_ACCOUNT:-all}-yesterday-$DATE.txt
 REPORT_FULL=/tmp/report-full-${EASY_ACCOUNT:-all}-$DATE.csv
+REPORT_FULL_24=/tmp/report-full-${EASY_ACCOUNT:-all}-yesterday-$DATE.csv
 
 
 if [ "$FROM" == "" ]; then
@@ -52,13 +54,24 @@ exit_if_failed() {
 echo -n "Creating summary report for ${EASY_ACCOUNT:-all depositors}..."
 /opt/dans.knaw.nl/easy-manage-deposit/bin/easy-manage-deposit summary $EASY_ACCOUNT > $REPORT_SUMMARY
 exit_if_failed "summary report failed"
+
+echo -n "Creating summary report from the last 24 hours for ${EASY_ACCOUNT:-all depositors}..."
+/opt/dans.knaw.nl/easy-manage-deposit/bin/easy-manage-deposit summary --age 0 $EASY_ACCOUNT > $REPORT_SUMMARY_24
+exit_if_failed "summary report failed"
+
 echo -n "Creating full report for ${EASY_ACCOUNT:-all depositors}..."
 /opt/dans.knaw.nl/easy-manage-deposit/bin/easy-manage-deposit full $EASY_ACCOUNT > $REPORT_FULL
+exit_if_failed "full report failed"
+
+echo -n "Creating full report from the last 24 hours for ${EASY_ACCOUNT:-all depositors}..."
+/opt/dans.knaw.nl/easy-manage-deposit/bin/easy-manage-deposit full --age 0 $EASY_ACCOUNT > $REPORT_FULL_24
 exit_if_failed "full report failed"
 
 echo "Status of $EASY_HOST deposits d.d. $(date) for depositor: ${EASY_ACCOUNT:-all}" | \
 mail -s "$EASY_HOST Report: status of EASY deposits (${EASY_ACCOUNT:-all depositors})" \
      -a $REPORT_SUMMARY \
+     -a $REPORT_SUMMARY_24 \
      -a $REPORT_FULL \
+     -a $REPORT_FULL_24 \
      $BCC_EMAILS $FROM_EMAIL $TO
 exit_if_failed "sending of e-mail failed"

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
@@ -45,9 +45,9 @@ object Command extends App with DebugEnhancedLogging {
 
   val result: Try[FeedBackMessage] = commandLine.subcommands match {
     case commandLine.reportCmd :: (full @ commandLine.reportCmd.fullCmd) :: Nil =>
-      app.createFullReport(full.depositor.toOption)
+      app.createFullReport(full.depositor.toOption, full.age.toOption)
     case commandLine.reportCmd :: (summary @ commandLine.reportCmd.summaryCmd) :: Nil =>
-      app.summary(summary.depositor.toOption)
+      app.summary(summary.depositor.toOption, summary.age.toOption)
     case (clean @ commandLine.cleanCmd) :: Nil =>
       if (cleanInteraction)
         app.cleanDepositor(clean.depositor.toOption, clean.keep(), clean.state(), clean.dataOnly())

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
@@ -48,6 +48,8 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
 
     val fullCmd = new Subcommand("full") {
       val depositor: ScallopOption[DepositorId] = trailArg("depositor", required = false)
+      val age: ScallopOption[Age] = opt[Age](name = "age", short = 'a', validate = 0 <,
+        descr = "Only report on the deposits that are less than n days old. An age argument of n=0 days corresponds to 0<=n<1. If this argument is nog provided, all deposits will be reported on.")
       descr("creates a full report for depositor(optional)")
       footer(SUBCOMMAND_SEPARATOR)
     }
@@ -55,6 +57,8 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
 
     val summaryCmd = new Subcommand("summary") {
       val depositor: ScallopOption[DepositorId] = trailArg("depositor", required = false)
+      val age: ScallopOption[Age] = opt[Age](name = "age", short = 'a', validate = 0 <,
+        descr = "Only report on the deposits that are less than n days old. An age argument of n=0 days corresponds to 0<=n<1. If this argument is nog provided, all deposits will be reported on.")
       descr("creates a summary report for depositor(optional)")
       footer(SUBCOMMAND_SEPARATOR)
     }

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
@@ -29,7 +29,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
     s"""
        |  $printedName report full [{--age|-a} <n>] [<depositor>]
        |  $printedName report summary [{--age|-a} <n>] [<depositor>]
-       |  $printedName clean [{--data-only}] [{--state} <state>] [{--keep} <n>] [<depositor>]
+       |  $printedName clean [{--data-only|-d}] [{--state|-s} <state>] [{--keep|-k} <n>] [<depositor>]
        |  $printedName retry [<depositor>]
      """.stripMargin
   version(s"$printedName v${ configuration.version }")

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
@@ -27,9 +27,9 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val description: String = s"""Manages the deposits in the deposit area."""
   val synopsis: String =
     s"""
-       |  $printedName report full [<depositor>]
-       |  $printedName report summary [<depositor>]
-       |  $printedName clean --data-only --state [<state>] --keep [<n>][<depositor>]
+       |  $printedName report full [{--age|-a} <n>] [<depositor>]
+       |  $printedName report summary [{--age|-a} <n>] [<depositor>]
+       |  $printedName clean [{--data-only}] [{--state} <state>] [{--keep} <n>] [<depositor>]
        |  $printedName retry [<depositor>]
      """.stripMargin
   version(s"$printedName v${ configuration.version }")

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
@@ -48,7 +48,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
 
     val fullCmd = new Subcommand("full") {
       val depositor: ScallopOption[DepositorId] = trailArg("depositor", required = false)
-      val age: ScallopOption[Age] = opt[Age](name = "age", short = 'a', validate = 0 <,
+      val age: ScallopOption[Age] = opt[Age](name = "age", short = 'a', validate = 0 <=,
         descr = "Only report on the deposits that are less than n days old. An age argument of n=0 days corresponds to 0<=n<1. If this argument is nog provided, all deposits will be reported on.")
       descr("creates a full report for depositor(optional)")
       footer(SUBCOMMAND_SEPARATOR)
@@ -57,7 +57,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
 
     val summaryCmd = new Subcommand("summary") {
       val depositor: ScallopOption[DepositorId] = trailArg("depositor", required = false)
-      val age: ScallopOption[Age] = opt[Age](name = "age", short = 'a', validate = 0 <,
+      val age: ScallopOption[Age] = opt[Age](name = "age", short = 'a', validate = 0 <=,
         descr = "Only report on the deposits that are less than n days old. An age argument of n=0 days corresponds to 0<=n<1. If this argument is nog provided, all deposits will be reported on.")
       descr("creates a summary report for depositor(optional)")
       footer(SUBCOMMAND_SEPARATOR)

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
@@ -27,9 +27,9 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val description: String = s"""Manages the deposits in the deposit area."""
   val synopsis: String =
     s"""
-       |  $printedName report full [{--age|-a} <n>] [<depositor>]
-       |  $printedName report summary [{--age|-a} <n>] [<depositor>]
-       |  $printedName clean [{--data-only|-d}] [{--state|-s} <state>] [{--keep|-k} <n>] [<depositor>]
+       |  $printedName report full [--age|-a <n>] [<depositor>]
+       |  $printedName report summary [--age|-a <n>] [<depositor>]
+       |  $printedName clean [--data-only|-d] [--state|-s <state>] [--keep|-k <n>] [<depositor>]
        |  $printedName retry [<depositor>]
      """.stripMargin
   version(s"$printedName v${ configuration.version }")

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
@@ -27,9 +27,9 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val description: String = s"""Manages the deposits in the deposit area."""
   val synopsis: String =
     s"""
-       |  $printedName report full [--age|-a <n>] [<depositor>]
-       |  $printedName report summary [--age|-a <n>] [<depositor>]
-       |  $printedName clean [--data-only|-d] [--state|-s <state>] [--keep|-k <n>] [<depositor>]
+       |  $printedName report full [--age, -a <n>] [<depositor>]
+       |  $printedName report summary [--age, -a <n>] [<depositor>]
+       |  $printedName clean [--data-only, -d] [--state, -s <state>] [--keep, -k <n>] [<depositor>]
        |  $printedName retry [<depositor>]
      """.stripMargin
   version(s"$printedName v${ configuration.version }")

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
@@ -27,9 +27,9 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
   val description: String = s"""Manages the deposits in the deposit area."""
   val synopsis: String =
     s"""
-       |  $printedName report full [--age, -a <n>] [<depositor>]
-       |  $printedName report summary [--age, -a <n>] [<depositor>]
-       |  $printedName clean [--data-only, -d] [--state, -s <state>] [--keep, -k <n>] [<depositor>]
+       |  $printedName report full [-a, --age <n>] [<depositor>]
+       |  $printedName report summary [-a, --age <n>] [<depositor>]
+       |  $printedName clean [-d, --data-only] [-s, --state <state>] [-k, --keep <n>] [<depositor>]
        |  $printedName retry [<depositor>]
      """.stripMargin
   version(s"$printedName v${ configuration.version }")

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
@@ -131,7 +131,7 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
     managed(Files.list(depositDirPath)).acquireAndGet { files =>
       files.map[Long](Files.getLastModifiedTime(_).toInstant.toEpochMilli)
         .max(LongComparator)
-        .map(millis => new DateTime(millis, DateTimeZone.UTC))
+        .map[DateTime](millis => new DateTime(millis, DateTimeZone.UTC))
         .toOption
     }
   }

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
@@ -43,8 +43,8 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
 
   private val end = DateTime.now(DateTimeZone.UTC)
 
-  private def collectDataFromDepositsDir(depositsDir: Path, filterOnDepositor: Option[DepositorId]): Deposits = {
-    depositsDir.list(collectDataFromDepositsDir(filterOnDepositor))
+  private def collectDataFromDepositsDir(depositsDir: Path, filterOnDepositor: Option[DepositorId], filterOnAge: Option[Age]): Deposits = {
+    depositsDir.list(collectDataFromDepositsDir(filterOnDepositor, filterOnAge))
   }
 
   def deleteDepositFromDepositsDir(depositsDir: Path, filterOnDepositor: Option[DepositorId], age: Int, state: String, onlyData: Boolean): Unit = {
@@ -55,7 +55,7 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
     depositsDir.list(retryStalledDeposit(filterOnDepositor))
   }
 
-  private def collectDataFromDepositsDir(filterOnDepositor: Option[DepositorId])(deposits: List[Path]): Deposits = {
+  private def collectDataFromDepositsDir(filterOnDepositor: Option[DepositorId], filterOnAge: Option[Age])(deposits: List[Path]): Deposits = {
     trace(filterOnDepositor)
     deposits.filter(Files.isDirectory(_))
       .flatMap { depositDirPath =>
@@ -64,8 +64,13 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
         val depositProperties = new PropertiesConfiguration(depositDirPath.resolve("deposit.properties").toFile)
         val depositorId = depositProperties.getString("depositor.userId")
 
+        lazy val lastModified: Option[DateTime] = getLastModifiedTimestamp(depositDirPath)
+
         // forall returns true for the empty set, see https://en.wikipedia.org/wiki/Vacuous_truth
-        if (filterOnDepositor.forall(depositorId ==)) Some {
+        val hasDepositor = filterOnDepositor.forall(depositorId ==)
+        lazy val shouldReport = filterOnAge.forall(age => lastModified.forall(mod => Duration.millis(DateTime.now(mod.getZone).getMillis - mod.getMillis).getStandardDays <= age))
+
+        if (hasDepositor && shouldReport) Some {
           Deposit(
             depositId = depositId,
             doi = getDoi(depositProperties, depositDirPath),
@@ -75,7 +80,7 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
             creationTimestamp = Option(depositProperties.getString("creation.timestamp")).getOrElse("n/a"),
             depositDirPath.list(_.count(_.getFileName.toString.matches("""^.*\.zip\.\d+$"""))),
             storageSpace = FileUtils.sizeOfDirectory(depositDirPath.toFile),
-            lastModified = getLastModifiedTimestamp(depositDirPath)
+            lastModified = lastModified.map(_.toString(dateTimeFormatter)).getOrElse("n/a")
           )
         }
         else None
@@ -122,12 +127,12 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
       }
   }
 
-  private def getLastModifiedTimestamp(depositDirPath: Path): String = {
+  private def getLastModifiedTimestamp(depositDirPath: Path): Option[DateTime] = {
     managed(Files.list(depositDirPath)).acquireAndGet { files =>
       files.map[Long](Files.getLastModifiedTime(_).toInstant.toEpochMilli)
         .max(LongComparator)
-        .map[String](millis => new DateTime(millis, DateTimeZone.UTC).toString(dateTimeFormatter))
-        .orElse("n/a")
+        .map(millis => new DateTime(millis, DateTimeZone.UTC))
+        .toOption
     }
   }
 
@@ -228,16 +233,16 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
     f"${ filterOnState }%-10s : ${ deposits.size }%5d (${ formatStorageSize(deposits.map(_.storageSpace).sum) })"
   }
 
-  def summary(depositor: Option[DepositorId] = None): Try[String] = Try {
-    val sword2Deposits = collectDataFromDepositsDir(sword2DepositsDir, depositor)
-    val ingestFlowDeposits = collectDataFromDepositsDir(ingestFlowInbox, depositor)
+  def summary(depositor: Option[DepositorId], age: Option[Age]): Try[String] = Try {
+    val sword2Deposits = collectDataFromDepositsDir(sword2DepositsDir, depositor, age)
+    val ingestFlowDeposits = collectDataFromDepositsDir(ingestFlowInbox, depositor, age)
     outputSummary(sword2Deposits ++ ingestFlowDeposits, depositor)
     "End of summary report."
   }
 
-  def createFullReport(depositor: Option[DepositorId]): Try[String] = Try {
-    val sword2Deposits = collectDataFromDepositsDir(sword2DepositsDir, depositor)
-    val ingestFlowDeposits = collectDataFromDepositsDir(ingestFlowInbox, depositor)
+  def createFullReport(depositor: Option[DepositorId], age: Option[Age]): Try[String] = Try {
+    val sword2Deposits = collectDataFromDepositsDir(sword2DepositsDir, depositor, age)
+    val ingestFlowDeposits = collectDataFromDepositsDir(ingestFlowInbox, depositor, age)
     outputFullReport(sword2Deposits ++ ingestFlowDeposits)
     "End of full report."
   }

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/package.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy
 
 import java.nio.file.{ Files, Path }
+import java.util.Optional
 
 import org.joda.time.format.{ DateTimeFormatter, ISODateTimeFormat }
 import resource._
@@ -27,6 +28,7 @@ package object managedeposit {
   type DepositId = String
   type Deposits = Seq[Deposit]
   type DepositorId = String
+  type Age = Int
 
   val XML_NAMESPACE_XSI = "http://www.w3.org/2001/XMLSchema-instance"
   val XML_NAMESPACE_ID_TYPE = "http://easy.dans.knaw.nl/schemas/vocab/identifier-type/"
@@ -37,5 +39,9 @@ package object managedeposit {
     def list[T](f: List[Path] => T): T = {
       managed(Files.list(path)).acquireAndGet(stream => f(stream.iterator().asScala.toList))
     }
+  }
+
+  implicit class Optional2Option[T](val opt: Optional[T]) extends AnyVal {
+    def toOption: Option[T] = opt.map(Option(_)).orElse(None)
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/package.scala
@@ -42,6 +42,6 @@ package object managedeposit {
   }
 
   implicit class Optional2Option[T](val opt: Optional[T]) extends AnyVal {
-    def toOption: Option[T] = opt.map(Option(_)).orElse(None)
+    def toOption: Option[T] = opt.map[Option[T]](Option(_)).orElse(None)
   }
 }


### PR DESCRIPTION
Fixes EASY-1482

#### When applied it will
* add an extra age parameter for full and summary reports
* adjust the documentation accordingly
* integrate the new parameter in `create-and-send-report.sh`

@DANS-KNAW/easy for review

@janvanmansum could you look extra carefully at the changes in `create-and-send-report.sh`?