### PR TITLE
Properties read bugfix

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
@@ -83,7 +83,7 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
             doi = getDoi(depositProperties, depositDirPath),
             depositorId,
             state = depositProperties.getString("state.label"),
-            description = depositProperties.getString("state.description"),
+            description = depositProperties.getString("state.description").replaceAll("\n", "").replaceAll("\t", ""),
             creationTimestamp = Option(depositProperties.getString("creation.timestamp")).getOrElse("n/a"),
             depositDirPath.list(_.count(_.getFileName.toString.matches("""^.*\.zip\.\d+$"""))),
             storageSpace = FileUtils.sizeOfDirectory(depositDirPath.toFile),

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
@@ -83,7 +83,7 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
             doi = getDoi(depositProperties, depositDirPath),
             depositorId,
             state = depositProperties.getString("state.label"),
-            description = depositProperties.getString("state.description").replaceAll("\n", "").replaceAll("\t", ""),
+            description = depositProperties.getString("state.description"),
             creationTimestamp = Option(depositProperties.getString("creation.timestamp")).getOrElse("n/a"),
             depositDirPath.list(_.count(_.getFileName.toString.matches("""^.*\.zip\.\d+$"""))),
             storageSpace = FileUtils.sizeOfDirectory(depositDirPath.toFile),


### PR DESCRIPTION
When `deposit.properties` is read, comma delimiters were not parsed correctly. ~~Also I removed `\n` and `\t` from the description, such that they get displayed in CSV/Excel correctly.~~

@DANS-KNAW/easy for review