### PR TITLE
EASY-2011: remove generated report files

### DIFF
--- a/src/main/assembly/dist/bin/create-and-send-error-report.sh
+++ b/src/main/assembly/dist/bin/create-and-send-error-report.sh
@@ -88,3 +88,8 @@ if [[ $LINE_COUNT -gt 1 || "$SEND_ALWAYS" = true ]]; then
 else
     echo "No new failed deposits were found, therefore no report was sent."
 fi
+
+echo -n "Remove generated report files"
+rm -f $REPORT_ERROR && \
+rm -f $REPORT_ERROR_24
+exit_if_failed "removing generated report file failed"

--- a/src/main/assembly/dist/bin/create-and-send-report.sh
+++ b/src/main/assembly/dist/bin/create-and-send-report.sh
@@ -100,3 +100,10 @@ if [[ $LINE_COUNT -gt 1 || "$SEND_ALWAYS" = true ]]; then
 else
     echo "No new deposits were done, therefore no report was sent."
 fi
+
+echo -n "Remove generated report files..."
+rm -f $REPORT_SUMMARY && \
+rm -f $REPORT_SUMMARY_24 && \
+rm -f $REPORT_FULL && \
+rm -f $REPORT_FULL_24
+exit_if_failed "removing generated report file failed"


### PR DESCRIPTION
Fixes EASY-2011

#### When applied it will
* remove generated report files in the `create-and-send-report` and `create-and-send-error-report` scripts

@DANS-KNAW/easy for review