### PR TITLE
NO JIRA. Added EASY_HOST to report failure message.

### DIFF
--- a/src/main/assembly/dist/bin/create-and-send-report.sh
+++ b/src/main/assembly/dist/bin/create-and-send-report.sh
@@ -59,7 +59,7 @@ exit_if_failed() {
     if [[ $EXITSTATUS != 0 ]]; then
         echo "ERROR: $1, exit status = $EXITSTATUS"
         echo "Report generation FAILED. Contact the system administrator." |
-        mail -s "FAILED: Report: status of EASY deposits (${EASY_ACCOUNT:-all depositors})" \
+        mail -s "FAILED: $EASY_HOST Report: status of EASY deposits (${EASY_ACCOUNT:-all depositors})" \
              $FROM_EMAIL $BCC_EMAILS $TO
         exit 1
     fi


### PR DESCRIPTION
NO JIRA.

#### When applied it will
* Mention the host name in the message that notifies about report generation failrue
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

