### PR TITLE
EASY-2173: 'origin' kolom voor deposit report

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositInformation.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositInformation.scala
@@ -30,6 +30,7 @@ case class DepositInformation(depositId: DepositId,
                               numberOfContinuedDeposits: Int,
                               storageSpace: Long,
                               lastModified: String,
+                              source: String,
                               location: String,
                               bagDirName: String,
                              )

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositInformation.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositInformation.scala
@@ -30,7 +30,7 @@ case class DepositInformation(depositId: DepositId,
                               numberOfContinuedDeposits: Int,
                               storageSpace: Long,
                               lastModified: String,
-                              source: String,
+                              location: String,
                               bagDirName: String,
                              )
                              (implicit dansDoiPrefixes: List[String]) {

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositInformation.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositInformation.scala
@@ -30,7 +30,7 @@ case class DepositInformation(depositId: DepositId,
                               numberOfContinuedDeposits: Int,
                               storageSpace: Long,
                               lastModified: String,
-                              source: String,
+                              origin: String,
                               location: String,
                               bagDirName: String,
                              )

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositManager.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositManager.scala
@@ -68,8 +68,8 @@ class DepositManager(val deposit: Deposit) extends DebugEnhancedLogging {
     getProperty("depositor.userId")
   }
 
-  def getDepositSource: Option[String] = {
-    getProperty("deposit.source")
+  def getDepositOrigin: Option[String] = {
+    getProperty("deposit.origin")
   }
 
   def getCreationTime: Option[DateTime] = {
@@ -131,7 +131,7 @@ class DepositManager(val deposit: Deposit) extends DebugEnhancedLogging {
       numberOfContinuedDeposits = getNumberOfContinuedDeposits,
       storageSpace = FileUtils.sizeOfDirectory(deposit.toFile),
       lastModified = lastModified.map(_.toString(dateTimeFormatter)).getOrElse(notAvailable),
-      source = getDepositSource.getOrElse(notAvailable),
+      origin = getDepositOrigin.getOrElse(notAvailable),
       location = location,
       getBagDirName.getOrElse(notAvailable),
     )

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositManager.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositManager.scala
@@ -68,6 +68,10 @@ class DepositManager(val deposit: Deposit) extends DebugEnhancedLogging {
     getProperty("depositor.userId")
   }
 
+  def getDepositSource: Option[String] = {
+    getProperty("deposit.source")
+  }
+
   def getCreationTime: Option[DateTime] = {
     getProperty("creation.timestamp").map(timeString => new DateTime(timeString))
   }
@@ -127,6 +131,7 @@ class DepositManager(val deposit: Deposit) extends DebugEnhancedLogging {
       numberOfContinuedDeposits = getNumberOfContinuedDeposits,
       storageSpace = FileUtils.sizeOfDirectory(deposit.toFile),
       lastModified = lastModified.map(_.toString(dateTimeFormatter)).getOrElse(notAvailable),
+      source = getDepositSource.getOrElse(notAvailable),
       location = location,
       getBagDirName.getOrElse(notAvailable),
     )

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositManager.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositManager.scala
@@ -114,7 +114,7 @@ class DepositManager(val deposit: Deposit) extends DebugEnhancedLogging {
     filterOnDepositor.forall(getDepositorId.getOrElse(notAvailable) ==)
   }
 
-  def getDepositInformation(source: String)(implicit dansDoiPrefixes: List[String]): Try[DepositInformation] = Try {
+  def getDepositInformation(location: String)(implicit dansDoiPrefixes: List[String]): Try[DepositInformation] = Try {
     DepositInformation(
       depositId = getDepositId.getOrElse(notAvailable),
       doiIdentifier = getDoi.map(_.getOrElse(notAvailable)).unsafeGetOrThrow,
@@ -127,7 +127,7 @@ class DepositManager(val deposit: Deposit) extends DebugEnhancedLogging {
       numberOfContinuedDeposits = getNumberOfContinuedDeposits,
       storageSpace = FileUtils.sizeOfDirectory(deposit.toFile),
       lastModified = lastModified.map(_.toString(dateTimeFormatter)).getOrElse(notAvailable),
-      source = source,
+      location = location,
       getBagDirName.getOrElse(notAvailable),
     )
   }.doIfFailure { case t: Throwable => logger.error(s"[${ deposit.getFileName }] Error while getting depositInformation: ${ t.getMessage }") }

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
@@ -43,8 +43,8 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
     .asScala.toList
     .map(prefix => prefix.asInstanceOf[String])
 
-  private def collectDataFromDepositsDir(depositsDir: Path, filterOnDepositor: Option[DepositorId], filterOnAge: Option[Age], source: String): Deposits = {
-    depositsDir.list(collectDataFromDepositsDir(filterOnDepositor, filterOnAge, source))
+  private def collectDataFromDepositsDir(depositsDir: Path, filterOnDepositor: Option[DepositorId], filterOnAge: Option[Age], location: String): Deposits = {
+    depositsDir.list(collectDataFromDepositsDir(filterOnDepositor, filterOnAge, location))
   }
 
   def deleteDepositFromDepositsDir(depositsDir: Path, filterOnDepositor: Option[DepositorId], age: Int, state: String, onlyData: Boolean): Try[Unit] = {
@@ -52,13 +52,13 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
     depositsDir.list(deleteDepositsFromDepositsDir(filterOnDepositor, age, toBeDeletedState, onlyData))
   }
 
-  private def collectDataFromDepositsDir(filterOnDepositor: Option[DepositorId], filterOnAge: Option[Age], source: String)(depositPaths: List[Path]): Deposits = {
+  private def collectDataFromDepositsDir(filterOnDepositor: Option[DepositorId], filterOnAge: Option[Age], location: String)(depositPaths: List[Path]): Deposits = {
     trace(filterOnDepositor)
     getDepositManagers(depositPaths)
       .withFilter(_.isValidDeposit)
       .withFilter(_.hasDepositor(filterOnDepositor))
       .withFilter(_.isOlderThan(filterOnAge))
-      .map(_.getDepositInformation(source))
+      .map(_.getDepositInformation(location))
       .collect { case Success(d: DepositInformation) => d }
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/ReportGenerator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/ReportGenerator.scala
@@ -87,7 +87,7 @@ object ReportGenerator {
         deposit.depositId,
         deposit.bagDirName,
         deposit.state,
-        deposit.source,
+        deposit.origin,
         deposit.location,
         deposit.doiIdentifier,
         deposit.registeredString,

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/ReportGenerator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/ReportGenerator.scala
@@ -75,7 +75,7 @@ object ReportGenerator {
 
   private def printRecords(deposits: Deposits)(implicit printStream: PrintStream): Unit = {
     val csvFormat: CSVFormat = CSVFormat.RFC4180
-      .withHeader("DEPOSITOR", "DEPOSIT_ID", "BAG_NAME", "DEPOSIT_STATE", "SOURCE", "DOI", "DOI_REGISTERED", "FEDORA_ID", "DEPOSIT_CREATION_TIMESTAMP",
+      .withHeader("DEPOSITOR", "DEPOSIT_ID", "BAG_NAME", "DEPOSIT_STATE", "LOCATION", "DOI", "DOI_REGISTERED", "FEDORA_ID", "DEPOSIT_CREATION_TIMESTAMP",
         "DEPOSIT_UPDATE_TIMESTAMP", "DESCRIPTION", "NBR_OF_CONTINUED_DEPOSITS", "STORAGE_IN_BYTES")
       .withDelimiter(',')
       .withRecordSeparator('\n')
@@ -87,7 +87,7 @@ object ReportGenerator {
         deposit.depositId,
         deposit.bagDirName,
         deposit.state,
-        deposit.source,
+        deposit.location,
         deposit.doiIdentifier,
         deposit.registeredString,
         deposit.fedoraIdentifier,

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/ReportGenerator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/ReportGenerator.scala
@@ -42,13 +42,13 @@ object ReportGenerator {
 
   def outputErrorReport(deposits: Deposits)(implicit printStream: PrintStream): Unit = {
     printRecords(deposits.filter {
-      case DepositInformation(_, _, _, _, _, INVALID, _, _, _, _, _, _, _) => true
-      case DepositInformation(_, _, _, _, _, FAILED, _, _, _, _, _, _, _) => true
-      case DepositInformation(_, _, _, _, _, REJECTED, _, _, _, _, _, _, _) => true
-      case DepositInformation(_, _, _, _, _, UNKNOWN, _, _, _, _, _, _, _) => true
-      case DepositInformation(_, _, _, _, _, null, _, _, _, _, _, _, _) => true
+      case DepositInformation(_, _, _, _, _, INVALID, _, _, _, _, _, _, _, _) => true
+      case DepositInformation(_, _, _, _, _, FAILED, _, _, _, _, _, _, _, _) => true
+      case DepositInformation(_, _, _, _, _, REJECTED, _, _, _, _, _, _, _, _) => true
+      case DepositInformation(_, _, _, _, _, UNKNOWN, _, _, _, _, _, _, _, _) => true
+      case DepositInformation(_, _, _, _, _, null, _, _, _, _, _, _, _, _) => true
       // When the doi of an archived deposit is NOT registered, an error should be raised
-      case d@DepositInformation(_, _, Some(false), _, _, ARCHIVED, _, _, _, _, _, _, _) if d.isDansDoi => true
+      case d@DepositInformation(_, _, Some(false), _, _, ARCHIVED, _, _, _, _, _, _, _, _) if d.isDansDoi => true
       case _ => false
     })
   }
@@ -75,7 +75,7 @@ object ReportGenerator {
 
   private def printRecords(deposits: Deposits)(implicit printStream: PrintStream): Unit = {
     val csvFormat: CSVFormat = CSVFormat.RFC4180
-      .withHeader("DEPOSITOR", "DEPOSIT_ID", "BAG_NAME", "DEPOSIT_STATE", "LOCATION", "DOI", "DOI_REGISTERED", "FEDORA_ID", "DEPOSIT_CREATION_TIMESTAMP",
+      .withHeader("DEPOSITOR", "DEPOSIT_ID", "BAG_NAME", "DEPOSIT_STATE", "SOURCE", "LOCATION", "DOI", "DOI_REGISTERED", "FEDORA_ID", "DEPOSIT_CREATION_TIMESTAMP",
         "DEPOSIT_UPDATE_TIMESTAMP", "DESCRIPTION", "NBR_OF_CONTINUED_DEPOSITS", "STORAGE_IN_BYTES")
       .withDelimiter(',')
       .withRecordSeparator('\n')
@@ -87,6 +87,7 @@ object ReportGenerator {
         deposit.depositId,
         deposit.bagDirName,
         deposit.state,
+        deposit.source,
         deposit.location,
         deposit.doiIdentifier,
         deposit.registeredString,

--- a/src/test/resources/inputForEasyManageDeposit/aba410b6-1a55-40b2-9ebe-6122aad00285/deposit.properties
+++ b/src/test/resources/inputForEasyManageDeposit/aba410b6-1a55-40b2-9ebe-6122aad00285/deposit.properties
@@ -11,3 +11,4 @@ identifier.fedora=fedora12345
 curation.required=true
 curation.performed=false
 bag-store.bag-name=baggy
+deposit.source=SWORD2

--- a/src/test/resources/inputForEasyManageDeposit/aba410b6-1a55-40b2-9ebe-6122aad00285/deposit.properties
+++ b/src/test/resources/inputForEasyManageDeposit/aba410b6-1a55-40b2-9ebe-6122aad00285/deposit.properties
@@ -11,4 +11,4 @@ identifier.fedora=fedora12345
 curation.required=true
 curation.performed=false
 bag-store.bag-name=baggy
-deposit.source=SWORD2
+deposit.origin=SWORD2

--- a/src/test/scala/nl.knaw.dans.easy.managedeposit/DepositInformationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.managedeposit/DepositInformationSpec.scala
@@ -22,7 +22,7 @@ class DepositInformationSpec extends FlatSpec with Matchers with OptionValues {
 
   private implicit val dansDoiPrefixes: List[String] = List("10.17026/", "10.5072/")
 
-  val deposit = DepositInformation("DepositId", "10.17026/dans-12345", Some(true), "123", "123", State.ARCHIVED, "description", "2000-01-01", 2, 1234L, "2000-01-02", "SRC1", "baggy")
+  val deposit = DepositInformation("DepositId", "10.17026/dans-12345", Some(true), "123", "123", State.ARCHIVED, "description", "2000-01-01", 2, 1234L, "2000-01-02", "SOURCE-1", "LOCATION-1", "baggy")
 
   "registeredString" should "return a yes when DANS DOI and DOI is registered" in {
     deposit.registeredString shouldBe "yes"

--- a/src/test/scala/nl.knaw.dans.easy.managedeposit/DepositInformationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.managedeposit/DepositInformationSpec.scala
@@ -22,7 +22,7 @@ class DepositInformationSpec extends FlatSpec with Matchers with OptionValues {
 
   private implicit val dansDoiPrefixes: List[String] = List("10.17026/", "10.5072/")
 
-  val deposit = DepositInformation("DepositId", "10.17026/dans-12345", Some(true), "123", "123", State.ARCHIVED, "description", "2000-01-01", 2, 1234L, "2000-01-02", "SOURCE-1", "LOCATION-1", "baggy")
+  val deposit = DepositInformation("DepositId", "10.17026/dans-12345", Some(true), "123", "123", State.ARCHIVED, "description", "2000-01-01", 2, 1234L, "2000-01-02", "ORIGIN-1", "LOCATION-1", "baggy")
 
   "registeredString" should "return a yes when DANS DOI and DOI is registered" in {
     deposit.registeredString shouldBe "yes"

--- a/src/test/scala/nl.knaw.dans.easy.managedeposit/DepositManagerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.managedeposit/DepositManagerSpec.scala
@@ -67,7 +67,7 @@ class DepositManagerSpec extends TestSupportFixture with BeforeAndAfterEach {
     depositManager.getStateDescription.value shouldBe "Deposit is valid and ready for post-submission processing"
     depositManager.getFedoraIdentifier.value shouldBe "fedora12345"
     depositManager.getDansDoiRegistered.value shouldBe "yes"
-    depositManager.getDepositSource.value shouldBe "SWORD2"
+    depositManager.getDepositOrigin.value shouldBe "SWORD2"
     depositManager.getDoiIdentifier.value shouldBe "aba410b6-9090-40b2-8080-6122aad00285"
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.managedeposit/DepositManagerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.managedeposit/DepositManagerSpec.scala
@@ -67,6 +67,7 @@ class DepositManagerSpec extends TestSupportFixture with BeforeAndAfterEach {
     depositManager.getStateDescription.value shouldBe "Deposit is valid and ready for post-submission processing"
     depositManager.getFedoraIdentifier.value shouldBe "fedora12345"
     depositManager.getDansDoiRegistered.value shouldBe "yes"
+    depositManager.getDepositSource.value shouldBe "SWORD2"
     depositManager.getDoiIdentifier.value shouldBe "aba410b6-9090-40b2-8080-6122aad00285"
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.managedeposit/ReportGeneratorSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.managedeposit/ReportGeneratorSpec.scala
@@ -198,7 +198,7 @@ class ReportGeneratorSpec extends TestSupportFixture
       s"${ deposit.depositId }," +
       s"${ deposit.bagDirName }," +
       s"${ Option(deposit.state).getOrElse("") }," +
-      s"${ deposit.source }," +
+      s"${ deposit.origin }," +
       s"${ deposit.location }," +
       s"${ deposit.doiIdentifier }," +
       s"${ deposit.registeredString }," +
@@ -211,7 +211,7 @@ class ReportGeneratorSpec extends TestSupportFixture
   }
 
   private def createDeposit(depositorId: String, state: State, location: String): DepositInformation = {
-    DepositInformation(UUID.randomUUID().toString, "10.17026/dans-12345", Some(true), "FedoraId", depositorId, state, "", DateTime.now().minusDays(3).toString(), 2, 129000, "", location, "SWORD2", "baggy")
+    DepositInformation(UUID.randomUUID().toString, "10.17026/dans-12345", Some(true), "FedoraId", depositorId, state, "", DateTime.now().minusDays(3).toString(), 2, 129000, "", "SWORD2", location, "baggy")
   }
 
   private def createDeposits = List(

--- a/src/test/scala/nl.knaw.dans.easy.managedeposit/ReportGeneratorSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.managedeposit/ReportGeneratorSpec.scala
@@ -198,6 +198,7 @@ class ReportGeneratorSpec extends TestSupportFixture
       s"${ deposit.depositId }," +
       s"${ deposit.bagDirName }," +
       s"${ Option(deposit.state).getOrElse("") }," +
+      s"${ deposit.source }," +
       s"${ deposit.location }," +
       s"${ deposit.doiIdentifier }," +
       s"${ deposit.registeredString }," +
@@ -210,7 +211,7 @@ class ReportGeneratorSpec extends TestSupportFixture
   }
 
   private def createDeposit(depositorId: String, state: State, location: String): DepositInformation = {
-    DepositInformation(UUID.randomUUID().toString, "10.17026/dans-12345", Some(true), "FedoraId", depositorId, state, "", DateTime.now().minusDays(3).toString(), 2, 129000, "", location, "baggy")
+    DepositInformation(UUID.randomUUID().toString, "10.17026/dans-12345", Some(true), "FedoraId", depositorId, state, "", DateTime.now().minusDays(3).toString(), 2, 129000, "", location, "SWORD2", "baggy")
   }
 
   private def createDeposits = List(

--- a/src/test/scala/nl.knaw.dans.easy.managedeposit/ReportGeneratorSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.managedeposit/ReportGeneratorSpec.scala
@@ -198,7 +198,7 @@ class ReportGeneratorSpec extends TestSupportFixture
       s"${ deposit.depositId }," +
       s"${ deposit.bagDirName }," +
       s"${ Option(deposit.state).getOrElse("") }," +
-      s"${ deposit.source }," +
+      s"${ deposit.location }," +
       s"${ deposit.doiIdentifier }," +
       s"${ deposit.registeredString }," +
       s"${ deposit.fedoraIdentifier.toString }," +
@@ -209,8 +209,8 @@ class ReportGeneratorSpec extends TestSupportFixture
       s"${ deposit.storageSpace.toString }"
   }
 
-  private def createDeposit(depositorId: String, state: State, source: String): DepositInformation = {
-    DepositInformation(UUID.randomUUID().toString, "10.17026/dans-12345", Some(true), "FedoraId", depositorId, state, "", DateTime.now().minusDays(3).toString(), 2, 129000, "", source, "baggy")
+  private def createDeposit(depositorId: String, state: State, location: String): DepositInformation = {
+    DepositInformation(UUID.randomUUID().toString, "10.17026/dans-12345", Some(true), "FedoraId", depositorId, state, "", DateTime.now().minusDays(3).toString(), 2, 129000, "", location, "baggy")
   }
 
   private def createDeposits = List(


### PR DESCRIPTION
Fixes EASY-2173

#### When applied it will
* add a new column `source` to the `easy-manage-deposits` report (value for this field read from `deposit.properties`)
* rename the current `source` column to `location`


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-sword2                      | [PR#132](https://github.com/DANS-KNAW/easy-sword2/pull/132)     | ..
easy-split-multi-deposit                      | [PR#138](https://github.com/DANS-KNAW/easy-split-multi-deposit/pull/138)     | ..
easy-deposit-api                      | [PR#166](https://github.com/DANS-KNAW/easy-deposit-api/pull/166)     | ..
easy-specs                     | [PR#82](https://github.com/DANS-KNAW/easy-specs/pull/82)     | ..

