### PR TITLE
EASY-1945: upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>5.1.0</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,6 @@
         <dependency>
             <groupId>org.rogach</groupId>
             <artifactId>scallop_2.12</artifactId>
-            <version>3.2.0</version>
         </dependency>
         <dependency>
             <groupId>commons-configuration</groupId>

--- a/src/test/scala/nl.knaw.dans.easy.managedeposit/ReportGeneratorSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.managedeposit/ReportGeneratorSpec.scala
@@ -107,19 +107,19 @@ class ReportGeneratorSpec extends TestSupportFixture
          |-------------
          |Timestamp          : $currentTime
          |Number of deposits :         16
-         |Total space        :      2.0 M
+         |Total space        :      2,0 M
          |
          |Per state:
          |----------
-         |ARCHIVED        :     2 (   252.0 K)
-         |DRAFT           :     1 (   126.0 K)
-         |FEDORA_ARCHIVED :     1 (   126.0 K)
-         |FINALIZING      :     1 (   126.0 K)
-         |IN_REVIEW       :     1 (   126.0 K)
-         |INVALID         :     1 (   126.0 K)
-         |REJECTED        :     1 (   126.0 K)
-         |SUBMITTED       :     4 (   503.9 K)
-         |UNKNOWN         :     4 (   503.9 K)""".stripMargin
+         |ARCHIVED        :     2 (   252,0 K)
+         |DRAFT           :     1 (   126,0 K)
+         |FEDORA_ARCHIVED :     1 (   126,0 K)
+         |FINALIZING      :     1 (   126,0 K)
+         |IN_REVIEW       :     1 (   126,0 K)
+         |INVALID         :     1 (   126,0 K)
+         |REJECTED        :     1 (   126,0 K)
+         |SUBMITTED       :     4 (   503,9 K)
+         |UNKNOWN         :     4 (   503,9 K)""".stripMargin
   }
 
   it should "produce a report when no deposits are found" in {
@@ -139,7 +139,7 @@ class ReportGeneratorSpec extends TestSupportFixture
          |-------------
          |Timestamp          : $currentTime
          |Number of deposits :          0
-         |Total space        :      0.0 B
+         |Total space        :      0,0 B
          |
          |Per state:
          |----------""".stripMargin
@@ -163,18 +163,18 @@ class ReportGeneratorSpec extends TestSupportFixture
          |-------------
          |Timestamp          : $currentTime
          |Number of deposits :         15
-         |Total space        :      1.8 M
+         |Total space        :      1,8 M
          |
          |Per state:
          |----------
-         |ARCHIVED   :     2 (   252.0 K)
-         |DRAFT      :     1 (   126.0 K)
-         |FINALIZING :     1 (   126.0 K)
-         |IN_REVIEW  :     1 (   126.0 K)
-         |INVALID    :     1 (   126.0 K)
-         |REJECTED   :     1 (   126.0 K)
-         |SUBMITTED  :     4 (   503.9 K)
-         |UNKNOWN    :     4 (   503.9 K)""".stripMargin
+         |ARCHIVED   :     2 (   252,0 K)
+         |DRAFT      :     1 (   126,0 K)
+         |FINALIZING :     1 (   126,0 K)
+         |IN_REVIEW  :     1 (   126,0 K)
+         |INVALID    :     1 (   126,0 K)
+         |REJECTED   :     1 (   126,0 K)
+         |SUBMITTED  :     4 (   503,9 K)
+         |UNKNOWN    :     4 (   503,9 K)""".stripMargin
   }
 
   "outputErrorReport" should "only print the deposits containing an error" in {
@@ -243,7 +243,7 @@ class ReportGeneratorSpec extends TestSupportFixture
     outputReportManged(ps, depositsInReport ::: depositsNotInReport, ReportType.ERROR)
 
     val errorReport = baos.toString
-    errorReport.lines.toList should have length depositsInReport.size + 1 // 1x header + |depositsInReport| 
+    errorReport.linesIterator.toList should have length depositsInReport.size + 1 // 1x header + |depositsInReport|
     forEvery(depositsInReport)(deposit => errorReport should include(createCsvRow(deposit)))
     forEvery(depositsNotInReport)(deposit => errorReport should not include createCsvRow(deposit))
   }

--- a/src/test/scala/nl.knaw.dans.easy.managedeposit/ReportGeneratorSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.managedeposit/ReportGeneratorSpec.scala
@@ -107,19 +107,19 @@ class ReportGeneratorSpec extends TestSupportFixture
          |-------------
          |Timestamp          : $currentTime
          |Number of deposits :         16
-         |Total space        :      2,0 M
+         |Total space        :      2.0 M
          |
          |Per state:
          |----------
-         |ARCHIVED        :     2 (   252,0 K)
-         |DRAFT           :     1 (   126,0 K)
-         |FEDORA_ARCHIVED :     1 (   126,0 K)
-         |FINALIZING      :     1 (   126,0 K)
-         |IN_REVIEW       :     1 (   126,0 K)
-         |INVALID         :     1 (   126,0 K)
-         |REJECTED        :     1 (   126,0 K)
-         |SUBMITTED       :     4 (   503,9 K)
-         |UNKNOWN         :     4 (   503,9 K)""".stripMargin
+         |ARCHIVED        :     2 (   252.0 K)
+         |DRAFT           :     1 (   126.0 K)
+         |FEDORA_ARCHIVED :     1 (   126.0 K)
+         |FINALIZING      :     1 (   126.0 K)
+         |IN_REVIEW       :     1 (   126.0 K)
+         |INVALID         :     1 (   126.0 K)
+         |REJECTED        :     1 (   126.0 K)
+         |SUBMITTED       :     4 (   503.9 K)
+         |UNKNOWN         :     4 (   503.9 K)""".stripMargin
   }
 
   it should "produce a report when no deposits are found" in {
@@ -139,7 +139,7 @@ class ReportGeneratorSpec extends TestSupportFixture
          |-------------
          |Timestamp          : $currentTime
          |Number of deposits :          0
-         |Total space        :      0,0 B
+         |Total space        :      0.0 B
          |
          |Per state:
          |----------""".stripMargin
@@ -163,18 +163,18 @@ class ReportGeneratorSpec extends TestSupportFixture
          |-------------
          |Timestamp          : $currentTime
          |Number of deposits :         15
-         |Total space        :      1,8 M
+         |Total space        :      1.8 M
          |
          |Per state:
          |----------
-         |ARCHIVED   :     2 (   252,0 K)
-         |DRAFT      :     1 (   126,0 K)
-         |FINALIZING :     1 (   126,0 K)
-         |IN_REVIEW  :     1 (   126,0 K)
-         |INVALID    :     1 (   126,0 K)
-         |REJECTED   :     1 (   126,0 K)
-         |SUBMITTED  :     4 (   503,9 K)
-         |UNKNOWN    :     4 (   503,9 K)""".stripMargin
+         |ARCHIVED   :     2 (   252.0 K)
+         |DRAFT      :     1 (   126.0 K)
+         |FINALIZING :     1 (   126.0 K)
+         |IN_REVIEW  :     1 (   126.0 K)
+         |INVALID    :     1 (   126.0 K)
+         |REJECTED   :     1 (   126.0 K)
+         |SUBMITTED  :     4 (   503.9 K)
+         |UNKNOWN    :     4 (   503.9 K)""".stripMargin
   }
 
   "outputErrorReport" should "only print the deposits containing an error" in {


### PR DESCRIPTION
Fixes EASY-1945

#### When applied it will
* upgrade parent POM version
* remove self-contained dependency version tags
* change `lines.toList` to `linesIterator.toList` due to https://github.com/scala/bug/issues/11125

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 