### PR TITLE
EASY-2833 Deposit.properties as a Service

### DIFF
--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -48,10 +48,12 @@ paths:
           description: OK. Content `deposit.properties` in body of response.
         404:
           description: Not Found. No `deposit.properties` available for the given UUID.
-    put:
-      summary: Adds or overwrites the deposit.properties record for the given UUID.
+
+  /deposits/{uuid}/load:
+    post:
+      summary: Loads the current properties from disk overwriting the old record
       description: |
-        The request body must contain the contents of the `deposit.properties` file to be stored. It must be in Java properties
+        The
         format and at minimum contain values for the following keys:
 
         * `state.label`
@@ -70,4 +72,5 @@ paths:
           description: Created. The `deposit.properties` were written to the dabase.
         400:
           description: Bad Request. Body was not in Java properties format or did not contain the minimally required fields.
-
+        404:
+          description: Not Found. The uuid referred to a deposit not found in the deposit area

--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -70,7 +70,5 @@ paths:
           description: OK. The `deposit.properties` were written to the dabase.
         201:
           description: Created. The `deposit.properties` were written to the dabase.
-        400:
-          description: Bad Request. Body was not in Java properties format or did not contain the minimally required fields.
         404:
           description: Not Found. The uuid referred to a deposit not found in the deposit area

--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -68,7 +68,5 @@ paths:
       responses:
         200:
           description: OK. The `deposit.properties` were written to the dabase.
-        201:
-          description: Created. The `deposit.properties` were written to the dabase.
         404:
           description: Not Found. The uuid referred to a deposit not found in the deposit area

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,11 +9,12 @@ SYNOPSIS
     easy-manage-deposit report full [-a, --age <n>] [-m, --datamanager <uid>] [<depositor>]
     easy-manage-deposit report summary [-a, --age <n>] [-m, --datamanager <uid>] [<depositor>]
     easy-manage-deposit report error [-a, --age <n>] [-m, --datamanager <uid>] [<depositor>]
-    easy-manage-deposit report raw [<location>]
     easy-manage-deposit clean [-d, --data-only] [-s, --state <state>] [-k, --keep <n>]  \
             [-l, --new-state-label <state>] [-n, --new-state-description <description>] \
             [-f, --force] [-o, --output] [--do-update] [<depositor>]
     easy-manage-deposit sync-fedora-state <easy-dataset-id>
+    easy-manage-deposit load-properties [l, --location {SWORD2|INGEST_FLOW|INGEST_FLOW_ARCHIVED}] <uuid>
+    easy-manage-deposit delete-properties
     easy-manage-deposit run-service
 
 ARGUMENTS

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 easy-manage-deposit
 ===================
 
-Manage DANS deposit directories.
+Manage the deposit area.
 
 SYNOPSIS
 --------
@@ -9,130 +9,339 @@ SYNOPSIS
     easy-manage-deposit report full [-a, --age <n>] [-m, --datamanager <uid>] [<depositor>]
     easy-manage-deposit report summary [-a, --age <n>] [-m, --datamanager <uid>] [<depositor>]
     easy-manage-deposit report error [-a, --age <n>] [-m, --datamanager <uid>] [<depositor>]
+    easy-manage-deposit report raw [<location>]
     easy-manage-deposit clean [-d, --data-only] [-s, --state <state>] [-k, --keep <n>]  \
             [-l, --new-state-label <state>] [-n, --new-state-description <description>] \
             [-f, --force] [-o, --output] [--do-update] [<depositor>]
     easy-manage-deposit sync-fedora-state <easy-dataset-id>
-    easy-manage-deposit load-properties [l, --location {SWORD2|INGEST_FLOW|INGEST_FLOW_ARCHIVED}] <uuid>
-    easy-manage-deposit delete-properties
     easy-manage-deposit run-service
 
 ARGUMENTS
 --------
 
-     Options:
-            -h, --help      Show help message
-            -v, --version   Show version of this program
-          
-          Subcommand: report
-            -h, --help   Show help message
-          
-          Subcommand: report full - creates a full report for a depositor and/or datamanager
-            -a, --age  <arg>           Only report on the deposits that are less than n
-                                       days old. An age argument of n=0 days corresponds
-                                       to 0<=n<1. If this argument is not provided, all
-                                       deposits will be reported on.
-            -m, --datamanager  <arg>   Only report on the deposits that are assigned to
-                                       this datamanager.
-            -h, --help                 Show help message
-          
-           trailing arguments:
-            depositor (not required)
-          ---
-          
-          Subcommand: report summary - creates a summary report for a depositor and/or datamanager
-            -a, --age  <arg>           Only report on the deposits that are less than n
-                                       days old. An age argument of n=0 days corresponds
-                                       to 0<=n<1. If this argument is not provided, all
-                                       deposits will be reported on.
-            -m, --datamanager  <arg>   Only report on the deposits that are assigned to
-                                       this datamanager.
-            -h, --help                 Show help message
-          
-           trailing arguments:
-            depositor (not required)
-          ---
-          
-          Subcommand: report error - creates a report displaying all failed, rejected and invalid deposits for a depositor and/or datamanager
-            -a, --age  <arg>           Only report on the deposits that are less than n
-                                       days old. An age argument of n=0 days corresponds
-                                       to 0<=n<1. If this argument is not provided, all
-                                       deposits will be reported on.
-            -m, --datamanager  <arg>   Only report on the deposits that are assigned to
-                                       this datamanager.
-            -h, --help                 Show help message
-          
-           trailing arguments:
-            depositor (not required)
-          ---
-          
-          Subcommand: report raw - creates a report containing all content of deposit.properties without inferring any properties
-            -h, --help   Show help message
-          
-           trailing arguments:
-            location (required)
-          ---
-          Subcommand: clean - removes deposit with specified state
-            -d, --data-only                      If specified, the deposit.properties and
-                                                 the container file of the deposit are not
-                                                 deleted
-                --do-update                      Do the actual deleting of deposits and
-                                                 updating of deposit.properties
-            -f, --force                          The user is not asked for a confirmation
-            -k, --keep  <arg>                    The deposits whose ages are greater than
-                                                 or equal to the argument n (days) are
-                                                 deleted. An age argument of n=0 days
-                                                 corresponds to 0<=n<1. (default = -1)
-            -n, --new-state-description  <arg>   The state description in
-                                                 deposit.properties after the deposit has
-                                                 been deleted
-            -l, --new-state-label  <arg>         The state label in deposit.properties
-                                                 after the deposit has been deleted
-            -o, --output                         Output a list of depositIds of the
-                                                 deposits that were deleted
-            -s, --state  <arg>                   The deposits with the specified state
-                                                 argument are deleted
-            -h, --help                           Show help message
-            
-           trailing arguments:
-            depositor (not required)
-          ---
-          
-          Subcommand: sync-fedora-state - Syncs a deposit with Fedora, checks if the deposit is properly registered in Fedora and updates the deposit.properties accordingly
-            -h, --help   Show help message
-          
-           trailing arguments:
-            easy-dataset-id (required)   The dataset identifier of the deposit which
-                                         deposit.properties are being synced with Fedora
-          ---
+    Options:
 
-          Subcommand: delete-properties - Deletes selected properties from the databse
-            -l, --location  <arg>   Only delete deposits from this location (one of:
-            SWORD2, INGEST_FLOW, INGEST_FLOW_ARCHIVED
-            -h, --help              Show help message
-        
-            trailing arguments:
-              uuid (not required)   Only load this deposit
-          ---
-        
-          Subcommand: load-properties - (Re-)loads the deposit properties into the database, overwriting the current records
-            -l, --location  <arg>   Only load deposits from this location (one of: SWORD2,
-               INGEST_FLOW, INGEST_FLOW_ARCHIVED
-            -h, --help              Show help message
-        
-            trailing arguments:
-              uuid (not required)   Only load this deposit
-          ---
 
-          Subcommand: run-service - Starts EASY Manage Deposit as a daemon
-          -h, --help   Show help message
-          ---
+      -h, --help      Show help message
+      -v, --version   Show version of this program
 
+    Subcommand: report
+      -h, --help   Show help message
+
+    Subcommand: report full - creates a full report for a depositor and/or datamanager
+      -a, --age  <arg>           Only report on the deposits that are less than n
+                                 days old. An age argument of n=0 days corresponds
+                                 to 0<=n<1. If this argument is not provided, all
+                                 deposits will be reported on.
+      -m, --datamanager  <arg>   Only report on the deposits that are assigned to
+                                 this datamanager.
+      -h, --help                 Show help message
+
+     trailing arguments:
+      depositor (not required)
+    ---
+
+    Subcommand: report summary - creates a summary report for a depositor and/or datamanager
+      -a, --age  <arg>           Only report on the deposits that are less than n
+                                 days old. An age argument of n=0 days corresponds
+                                 to 0<=n<1. If this argument is not provided, all
+                                 deposits will be reported on.
+      -m, --datamanager  <arg>   Only report on the deposits that are assigned to
+                                 this datamanager.
+      -h, --help                 Show help message
+
+     trailing arguments:
+      depositor (not required)
+    ---
+
+    Subcommand: report error - creates a report displaying all failed, rejected and invalid deposits for a depositor and/or datamanager
+      -a, --age  <arg>           Only report on the deposits that are less than n
+                                 days old. An age argument of n=0 days corresponds
+                                 to 0<=n<1. If this argument is not provided, all
+                                 deposits will be reported on.
+      -m, --datamanager  <arg>   Only report on the deposits that are assigned to
+                                 this datamanager.
+      -h, --help                 Show help message
+
+     trailing arguments:
+      depositor (not required)
+    ---
+
+    Subcommand: report raw - creates a report containing all content of deposit.properties without inferring any properties
+      -h, --help   Show help message
+
+     trailing arguments:
+      location (required)
+    ---
+    Subcommand: report-old
+      -h, --help   Show help message
+
+    Subcommand: report-old full - creates a full report for a depositor and/or datamanager
+      -a, --age  <arg>           Only report on the deposits that are less than n
+                                 days old. An age argument of n=0 days corresponds
+                                 to 0<=n<1. If this argument is not provided, all
+                                 deposits will be reported on.
+      -m, --datamanager  <arg>   Only report on the deposits that are assigned to
+                                 this datamanager.
+      -h, --help                 Show help message
+
+     trailing arguments:
+      depositor (not required)
+    ---
+
+    Subcommand: report-old summary - creates a summary report for a depositor and/or datamanager
+      -a, --age  <arg>           Only report on the deposits that are less than n
+                                 days old. An age argument of n=0 days corresponds
+                                 to 0<=n<1. If this argument is not provided, all
+                                 deposits will be reported on.
+      -m, --datamanager  <arg>   Only report on the deposits that are assigned to
+                                 this datamanager.
+      -h, --help                 Show help message
+
+     trailing arguments:
+      depositor (not required)
+    ---
+
+    Subcommand: report-old error - creates a report displaying all failed, rejected and invalid deposits for a depositor and/or datamanager
+      -a, --age  <arg>           Only report on the deposits that are less than n
+                                 days old. An age argument of n=0 days corresponds
+                                 to 0<=n<1. If this argument is not provided, all
+                                 deposits will be reported on.
+      -m, --datamanager  <arg>   Only report on the deposits that are assigned to
+                                 this datamanager.
+      -h, --help                 Show help message
+
+     trailing arguments:
+      depositor (not required)
+    ---
+
+    Subcommand: report-old raw - creates a report containing all content of deposit.properties without inferring any properties
+      -h, --help   Show help message
+
+     trailing arguments:
+      location (required)
+    ---
+    Subcommand: clean - removes deposit with specified state
+      -d, --data-only                      If specified, the deposit.properties and
+                                           the container file of the deposit are not
+                                           deleted
+          --do-update                      Do the actual deleting of deposits and
+                                           updating of deposit.properties
+      -f, --force                          The user is not asked for a confirmation
+      -k, --keep  <arg>                    The deposits whose ages are greater than
+                                           or equal to the argument n (days) are
+                                           deleted. An age argument of n=0 days
+                                           corresponds to 0<=n<1. (default = -1)
+      -n, --new-state-description  <arg>   The state description in
+                                           deposit.properties after the deposit has
+                                           been deleted
+      -l, --new-state-label  <arg>         The state label in deposit.properties
+                                           after the deposit has been deleted
+      -o, --output                         Output a list of depositIds of the
+                                           deposits that were deleted
+      -s, --state  <arg>                   The deposits with the specified state
+                                           argument are deleted
+      -h, --help                           Show help message
+
+     trailing arguments:
+      depositor (not required)
+    ---
+
+    Subcommand: sync-fedora-state - Syncs a deposit with Fedora, checks if the deposit is properly registered in Fedora and updates the deposit.properties accordingly
+      -h, --help   Show help message
+
+     trailing arguments:
+      easy-dataset-id (required)   The dataset identifier of the deposit which
+                                   deposit.properties are being synced with Fedora
+    ---
+
+    Subcommand: delete-properties - Deletes selected properties from the databse
+      -a, --all               Delete all properties
+      -l, --location  <arg>   Only delete deposits from this location (one of:
+                              SWORD2, INGEST_FLOW, INGEST_FLOW_ARCHIVED
+      -h, --help              Show help message
+
+     trailing arguments:
+      uuid (not required)   Only load this deposit
+    ---
+
+    Subcommand: load-properties - (Re-)loads the deposit properties into the database, overwriting the current records
+      -l, --location  <arg>   Only load deposits from this location (one of: SWORD2,
+                              INGEST_FLOW, INGEST_FLOW_ARCHIVED
+      -h, --help              Show help message
+
+     trailing arguments:
+      uuid (not required)   Only load this deposit
+    ---
+
+    Subcommand: run-service - Starts EASY Manage Deposit as a daemon
+      -h, --help   Show help message
+    ---
+
+    (END)                                       updating of deposit.properties
+      -f, --force                          The user is not asked for a confirmation
+      -k, --keep  <arg>                    The deposits whose ages are greater than
+                                           or equal to the argument n (days) are
+                                           deleted. An age argument of n=0 days
+                                           corresponds to 0<=n<1. (default = -1)
+      -n, --new-state-description  <arg>   The state description in
+                                           deposit.properties after the deposit has
+                                           been deleted
+      -l, --new-state-label  <arg>         The state label in deposit.properties
+                                           after the deposit has been deleted
+      -o, --output                         Output a list of depositIds of the
+                                           deposits that were deleted
+      -s, --state  <arg>                   The deposits with the specified state
+                                           argument are deleted
+      -h, --help                           Show help message
+
+     trailing arguments:
+      depositor (not required)
+    ---
+
+    Subcommand: sync-fedora-state - Syncs a deposit with Fedora, checks if the deposit is properly registered in Fedora and updates the deposit.properties accordingly
+      -h, --help   Show help message
+
+     trailing arguments:
+      easy-dataset-id (required)   The dataset identifier of the deposit which
+                                   deposit.properties are being synced with Fedora
+    ---
+
+    Subcommand: delete-properties - Deletes selected properties from the databse
+      -a, --all               Delete all properties
+      -l, --location  <arg>   Only delete deposits from this location (one of:
+                              SWORD2, INGEST_FLOW, INGEST_FLOW_ARCHIVED
+      -h, --help              Show help message
+
+     trailing arguments:
+      uuid (not required)   Only load this deposit
+    ---
+
+    Subcommand: load-properties - (Re-)loads the deposit properties into the database, overwriting the current records
+      -l, --location  <arg>   Only load deposits from this location (one of: SWORD2,
+                              INGEST_FLOW, INGEST_FLOW_ARCHIVED
+      -h, --help              Show help message
+
+     trailing arguments:
+      uuid (not required)   Only load this deposit
+    ---
+    :                                       updating of deposit.properties
+      -f, --force                          The user is not asked for a confirmation
+      -k, --keep  <arg>                    The deposits whose ages are greater than
+                                           or equal to the argument n (days) are
+                                           deleted. An age argument of n=0 days
+                                           corresponds to 0<=n<1. (default = -1)
+      -n, --new-state-description  <arg>   The state description in
+                                           deposit.properties after the deposit has
+                                           been deleted
+      -l, --new-state-label  <arg>         The state label in deposit.properties
+                                           after the deposit has been deleted
+      -o, --output                         Output a list of depositIds of the
+                                           deposits that were deleted
+      -s, --state  <arg>                   The deposits with the specified state
+                                           argument are deleted
+      -h, --help                           Show help message
+
+     trailing arguments:
+      depositor (not required)
+    ---
+
+    Subcommand: sync-fedora-state - Syncs a deposit with Fedora, checks if the deposit is properly registered in Fedora and updates the deposit.properties accordingly
+      -h, --help   Show help message
+
+     trailing arguments:
+      easy-dataset-id (required)   The dataset identifier of the deposit which
+                                   deposit.properties are being synced with Fedora
+    ---
+
+    Subcommand: delete-properties - Deletes selected properties from the databse
+      -a, --all               Delete all properties
+      -l, --location  <arg>   Only delete deposits from this location (one of:
+                              SWORD2, INGEST_FLOW, INGEST_FLOW_ARCHIVED
+      -h, --help              Show help message
+
+     trailing arguments:
+      uuid (not required)   Only load this deposit
+    ---
+
+    Subcommand: load-properties - (Re-)loads the deposit properties into the database, overwriting the current records
+      -l, --location  <arg>   Only load deposits from this location (one of: SWORD2,
+                              INGEST_FLOW, INGEST_FLOW_ARCHIVED
+      -h, --help              Show help message
+
+     trailing arguments:
+      uuid (not required)   Only load this deposit
+    ---
+
+    Subcommand: run-service - Starts EASY Manage Deposit as a daemon
+    :                                       updating of deposit.properties
+      -f, --force                          The user is not asked for a confirmation
+      -k, --keep  <arg>                    The deposits whose ages are greater than
+                                           or equal to the argument n (days) are
+                                           deleted. An age argument of n=0 days
+                                           corresponds to 0<=n<1. (default = -1)
+      -n, --new-state-description  <arg>   The state description in
+                                           deposit.properties after the deposit has
+                                           been deleted
+      -l, --new-state-label  <arg>         The state label in deposit.properties
+                                           after the deposit has been deleted
+      -o, --output                         Output a list of depositIds of the
+                                           deposits that were deleted
+      -s, --state  <arg>                   The deposits with the specified state
+                                           argument are deleted
+      -h, --help                           Show help message
+
+     trailing arguments:
+      depositor (not required)
+    ---
+
+    Subcommand: sync-fedora-state - Syncs a deposit with Fedora, checks if the deposit is properly registered in Fedora and updates the deposit.properties accordingly
+      -h, --help   Show help message
+
+     trailing arguments:
+      easy-dataset-id (required)   The dataset identifier of the deposit which
+                                   deposit.properties are being synced with Fedora
+    ---
+
+    Subcommand: delete-properties - Deletes selected properties from the databse
+      -a, --all               Delete all properties
+      -l, --location  <arg>   Only delete deposits from this location (one of:
+                              SWORD2, INGEST_FLOW, INGEST_FLOW_ARCHIVED
+      -h, --help              Show help message
+
+     trailing arguments:
+      uuid (not required)   Only load this deposit
+    ---
+
+    Subcommand: load-properties - (Re-)loads the deposit properties into the database, overwriting the current records
+      -l, --location  <arg>   Only load deposits from this location (one of: SWORD2,
+                              INGEST_FLOW, INGEST_FLOW_ARCHIVED
+      -h, --help              Show help message
+
+     trailing arguments:
+      uuid (not required)   Only load this deposit
+    ---
+
+    Subcommand: run-service - Starts EASY Manage Deposit as a daemon
+      -h, --help   Show help message
+    ---
 
 DESCRIPTION
 -----------
-This module provides commands to manage [DANS deposit directories](https://dans-knaw.github.io/dd-dans-deposit-to-dataverse/deposit-directory/) 
-which are the unit of work for the automated deposit pipelines of EASY (legacy) and the DANS Data Stations.
+This utility provides commands to manage the deposit area. The deposit area is a set of directories used to receive and 
+process [DANS deposit directories](https://dans-knaw.github.io/dd-dans-deposit-to-dataverse/deposit-directory/). The 
+commands:
+
+* Generate reports about the the current contents of the deposit area.
+* Provide a way to clean up the deposit area, for example deleting DRAFT deposits that are older than a given number
+  of days and therefore deemed abandoned.
+  
+### Database & http interface
+To make the generations of reports more efficient a database with a copy of the properties is maintained. It serves as 
+an index of sorts. The report generation commands use the database instead of the `deposit.properties` files on disk, so it
+is important to keep the database up-to-date. To this end `easy-managed-deposit` contains a daemon with a simple HTTP 
+interface. The services that use the deposit area should always "re-index" deposits via this interface after making
+changes.
 
 EXAMPLES
 --------

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ SYNOPSIS
             [-l, --new-state-label <state>] [-n, --new-state-description <description>] \
             [-f, --force] [-o, --output] [--do-update] [<depositor>]
     easy-manage-deposit sync-fedora-state <easy-dataset-id>
+    easy-manage-deposit run-service
 
 ARGUMENTS
 --------
@@ -102,6 +103,10 @@ ARGUMENTS
            trailing arguments:
             easy-dataset-id (required)   The dataset identifier of the deposit which
                                          deposit.properties are being synced with Fedora
+          ---
+
+          Subcommand: run-service - Starts EASY Manage Deposit as a daemon
+          -h, --help   Show help message
           ---
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -106,10 +106,12 @@ ARGUMENTS
           ---
 
           Subcommand: load-properties - (Re-)loads the deposit properties into the database, overwriting the current records
-            -h, --help   Show help message
+            -l, --location  <arg>   Only load deposits from this location (one of: SWORD2,
+                            INGEST_FLOW, INGEST_FLOW_ARCHIVED
+            -h, --help              Show help message
 
             trailing arguments:
-             uuid (not required)   Only load this deposit
+              uuid (not required)   Only load this deposit
           ---
 
           Subcommand: run-service - Starts EASY Manage Deposit as a daemon

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,6 +105,14 @@ ARGUMENTS
                                          deposit.properties are being synced with Fedora
           ---
 
+          Subcommand: load-properties - Loads the deposit.properties from the specified directory in the database. By default the directory is expected to contain subdirectories that are deposits. To load one deposit, use the --single option
+            -s, --single   The directory is a single deposit
+            -h, --help     Show help message
+
+            trailing arguments:
+            directory (required)   The directory from which to load the deposit properties
+          ---
+
           Subcommand: run-service - Starts EASY Manage Deposit as a daemon
           -h, --help   Show help message
           ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,11 +105,20 @@ ARGUMENTS
                                          deposit.properties are being synced with Fedora
           ---
 
+          Subcommand: delete-properties - Deletes selected properties from the databse
+            -l, --location  <arg>   Only delete deposits from this location (one of:
+            SWORD2, INGEST_FLOW, INGEST_FLOW_ARCHIVED
+            -h, --help              Show help message
+        
+            trailing arguments:
+              uuid (not required)   Only load this deposit
+          ---
+        
           Subcommand: load-properties - (Re-)loads the deposit properties into the database, overwriting the current records
             -l, --location  <arg>   Only load deposits from this location (one of: SWORD2,
-                            INGEST_FLOW, INGEST_FLOW_ARCHIVED
+               INGEST_FLOW, INGEST_FLOW_ARCHIVED
             -h, --help              Show help message
-
+        
             trailing arguments:
               uuid (not required)   Only load this deposit
           ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,12 +105,11 @@ ARGUMENTS
                                          deposit.properties are being synced with Fedora
           ---
 
-          Subcommand: load-properties - Loads the deposit.properties from the specified directory in the database. By default the directory is expected to contain subdirectories that are deposits. To load one deposit, use the --single option
-            -s, --single   The directory is a single deposit
-            -h, --help     Show help message
+          Subcommand: load-properties - (Re-)loads the deposit properties into the database, overwriting the current records
+            -h, --help   Show help message
 
             trailing arguments:
-            directory (required)   The directory from which to load the deposit properties
+             uuid (not required)   Only load this deposit
           ---
 
           Subcommand: run-service - Starts EASY Manage Deposit as a daemon

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.3</version>
+        <version>6.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,18 @@
             <artifactId>fedora-client-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.scalatra</groupId>
+            <artifactId>scalatra_2.12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.pathikrit</groupId>
             <artifactId>better-files_2.12</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,14 @@
             <artifactId>better-files_2.12</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <version>3.3.6-SNAPSHOT</version>
     <name>EASY Manage Deposit</name>
     <url>https://github.com/DANS-KNAW/easy-manage-deposit</url>
-    <description>Manage DANS deposit directories.</description>
+    <description>Manage the deposit area.</description>
     <inceptionYear>2017</inceptionYear>
     <properties>
         <main-class>nl.knaw.dans.easy.managedeposit.Command</main-class>

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -1,5 +1,10 @@
 daemon.http.port=20240
 
+database.driver=org.postgresql.Driver
+database.url=jdbc:postgresql://localhost:5432/dd_migration_info
+database.user=dd_migration_info
+database.password=changeme
+
 easy-ingest-flow-inbox=/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox
 easy-ingest-flow-inbox-archived=/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox-archived
 easy-sword2=/var/opt/dans.knaw.nl/tmp/easy-sword2

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -1,3 +1,5 @@
+daemon.http.port=20240
+
 easy-ingest-flow-inbox=/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox
 easy-ingest-flow-inbox-archived=/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox-archived
 easy-sword2=/var/opt/dans.knaw.nl/tmp/easy-sword2

--- a/src/main/assembly/dist/install/charset.conf
+++ b/src/main/assembly/dist/install/charset.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment="LC_ALL=en_US.UTF-8"

--- a/src/main/assembly/dist/install/db-tables.sql
+++ b/src/main/assembly/dist/install/db-tables.sql
@@ -1,10 +1,10 @@
 CREATE TABLE IF NOT EXISTS deposit_properties (
     uuid CHAR(36) NOT NULL,
-    last_modified TIMESTAMP,
+    last_modified TIMESTAMP NOT NULL,
     properties TEXT NOT NULL,
-    status_label VARCHAR(30),
-    depositor_user_id VARCHAR(50),
+    status_label VARCHAR(30) NOT NULL,
+    depositor_user_id VARCHAR(50) NOT NULL,
     datamanager VARCHAR(50),
-    PRIMARY KEY (uuid);
+    PRIMARY KEY (uuid));
 
 GRANT INSERT, SELECT, UPDATE, DELETE ON deposit_properties TO easy_manage_deposit;

--- a/src/main/assembly/dist/install/db-tables.sql
+++ b/src/main/assembly/dist/install/db-tables.sql
@@ -5,8 +5,10 @@ CREATE TABLE IF NOT EXISTS deposit_properties (
     state_label VARCHAR(30) NOT NULL,
     depositor_user_id VARCHAR(50) NOT NULL,
     datamanager VARCHAR(50),
-    storage_size_in_bytes bigint NOT NULL,
     location VARCHAR(100) NOT NULL,
+    has_bag BOOLEAN NOT NULL,
+    storage_size_in_bytes bigint NOT NULL,
+    number_of_continued_deposits INTEGER NOT NULL,
     PRIMARY KEY (uuid));
 
 GRANT INSERT, SELECT, UPDATE, DELETE ON deposit_properties TO easy_manage_deposit;

--- a/src/main/assembly/dist/install/db-tables.sql
+++ b/src/main/assembly/dist/install/db-tables.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS deposit_properties (
+    uuid CHAR(36) NOT NULL,
+    last_modified TIMESTAMP,
+    properties TEXT NOT NULL,
+    status_label VARCHAR(30),
+    depositor_user_id VARCHAR(50),
+    datamanager VARCHAR(50),
+    PRIMARY KEY (uuid);
+
+GRANT INSERT, SELECT, UPDATE, DELETE ON deposit_properties TO easy_manage_deposit;

--- a/src/main/assembly/dist/install/db-tables.sql
+++ b/src/main/assembly/dist/install/db-tables.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS deposit_properties (
     depositor_user_id VARCHAR(50) NOT NULL,
     datamanager VARCHAR(50),
     storage_size_in_bytes bigint NOT NULL,
-    location VARCHAR(100) NOT NULL
+    location VARCHAR(100) NOT NULL,
     PRIMARY KEY (uuid));
 
 GRANT INSERT, SELECT, UPDATE, DELETE ON deposit_properties TO easy_manage_deposit;

--- a/src/main/assembly/dist/install/db-tables.sql
+++ b/src/main/assembly/dist/install/db-tables.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS deposit_properties (
     uuid CHAR(36) NOT NULL,
     last_modified TIMESTAMP NOT NULL,
     properties TEXT NOT NULL,
-    status_label VARCHAR(30) NOT NULL,
+    state_label VARCHAR(30) NOT NULL,
     depositor_user_id VARCHAR(50) NOT NULL,
     datamanager VARCHAR(50),
     PRIMARY KEY (uuid));

--- a/src/main/assembly/dist/install/db-tables.sql
+++ b/src/main/assembly/dist/install/db-tables.sql
@@ -10,5 +10,9 @@ CREATE TABLE IF NOT EXISTS deposit_properties (
     storage_size_in_bytes bigint NOT NULL,
     number_of_continued_deposits INTEGER NOT NULL,
     PRIMARY KEY (uuid));
+CREATE INDEX last_modified_idx ON deposit_properties(last_modified);
+CREATE INDEX state_label_idx ON deposit_properties(state_label);
+CREATE INDEX depositor_user_id_idx ON deposit_properties(depositor_user_id);
+CREATE INDEX datamanager_idx ON deposit_properties(datamanager);
 
 GRANT INSERT, SELECT, UPDATE, DELETE ON deposit_properties TO easy_manage_deposit;

--- a/src/main/assembly/dist/install/db-tables.sql
+++ b/src/main/assembly/dist/install/db-tables.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS deposit_properties (
     uuid CHAR(36) NOT NULL,
-    last_modified TIMESTAMP NOT NULL,
+    last_modified TIMESTAMPTZ NOT NULL,
     properties TEXT NOT NULL,
     state_label VARCHAR(30) NOT NULL,
     depositor_user_id VARCHAR(50) NOT NULL,

--- a/src/main/assembly/dist/install/db-tables.sql
+++ b/src/main/assembly/dist/install/db-tables.sql
@@ -5,6 +5,8 @@ CREATE TABLE IF NOT EXISTS deposit_properties (
     state_label VARCHAR(30) NOT NULL,
     depositor_user_id VARCHAR(50) NOT NULL,
     datamanager VARCHAR(50),
+    storage_size_in_bytes bigint NOT NULL,
+    location VARCHAR(100) NOT NULL
     PRIMARY KEY (uuid));
 
 GRANT INSERT, SELECT, UPDATE, DELETE ON deposit_properties TO easy_manage_deposit;

--- a/src/main/assembly/dist/install/easy-manage-deposit.service
+++ b/src/main/assembly/dist/install/easy-manage-deposit.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=EASY Manage Deposit Service
+
+[Service]
+ExecStart=/bin/java \
+   $INITIAL_HEAP_SIZE \
+   -Dlogback.configurationFile=/etc/opt/dans.knaw.nl/easy-manage-deposit/logback-service.xml \
+   -Dapp.home=/opt/dans.knaw.nl/easy-manage-deposit \
+   -Dorg.scalatra.environment="production" \
+   -jar /opt/dans.knaw.nl/easy-manage-deposit/bin/easy-manage-deposit.jar run-service
+# Java returns 143 even if the SIGTERM was handled correctly.
+SuccessExitStatus=143
+
+User=easy-manage-deposit
+Group=easy-manage-deposit
+
+[Install]
+WantedBy=multi-user.target

--- a/src/main/assembly/dist/install/memusage.conf
+++ b/src/main/assembly/dist/install/memusage.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment="INITIAL_HEAP_SIZE=-Xms64m"

--- a/src/main/rpm/1-pre-install.sh
+++ b/src/main/rpm/1-pre-install.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#include <service.sh>
+
+NUMBER_OF_INSTALLATIONS=$1
+MODULE_NAME=easy-manage-deposit
+PHASE="PRE-INSTALL"
+
+echo "$PHASE: START (Number of current installations: $NUMBER_OF_INSTALLATIONS)"
+service_stop $MODULE_NAME $NUMBER_OF_INSTALLATIONS
+service_create_module_user $MODULE_NAME
+echo "$PHASE: DONE"

--- a/src/main/rpm/2-post-install.sh
+++ b/src/main/rpm/2-post-install.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#include <service.sh>
+
+NUMBER_OF_INSTALLATIONS=$1
+MODULE_NAME=easy-manage-deposit
+INSTALL_DIR=/opt/dans.knaw.nl/$MODULE_NAME
+PHASE="POST-INSTALL"
+
+echo "$PHASE: START (Number of current installations: $NUMBER_OF_INSTALLATIONS)"
+service_install_systemd_unit "$INSTALL_DIR/install/$MODULE_NAME.service" $MODULE_NAME "$INSTALL_DIR/install/charset.conf"
+service_install_systemd_unit "$INSTALL_DIR/install/$MODULE_NAME.service" $MODULE_NAME "$INSTALL_DIR/install/memusage.conf"
+
+service_create_log_directory $MODULE_NAME
+echo "$PHASE: DONE"

--- a/src/main/rpm/4-post-remove.sh
+++ b/src/main/rpm/4-post-remove.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#include <service.sh>
+
+NUMBER_OF_INSTALLATIONS=$1
+MODULE_NAME=easy-manage-deposit
+INSTALL_DIR=/opt/dans.knaw.nl/$MODULE_NAME
+PHASE="POST-REMOVE"
+
+echo "$PHASE: START (Number of current installations: $NUMBER_OF_INSTALLATIONS)"
+service_remove_systemd_unit $MODULE_NAME $NUMBER_OF_INSTALLATIONS
+echo "$PHASE: DONE"

--- a/src/main/rpm/5-post-trans.sh
+++ b/src/main/rpm/5-post-trans.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#include <service.sh>
+
+MODULE_NAME=easy-manage-deposit
+PHASE="POST-TRANS"
+
+echo "$PHASE: START"
+service_restart $MODULE_NAME
+echo "$PHASE: DONE"

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
@@ -44,18 +44,18 @@ object Command extends App with DebugEnhancedLogging {
 
   val result: Try[FeedBackMessage] = commandLine.subcommands match {
     case commandLine.reportCmd :: (full @ commandLine.reportCmd.fullCmd) :: Nil =>
-      app.createFullReport2(full.depositor.toOption, full.datamanager.toOption, full.age.toOption)
+      app.createFullReport(full.depositor.toOption, full.datamanager.toOption, full.age.toOption)
     case commandLine.reportCmd :: (summary @ commandLine.reportCmd.summaryCmd) :: Nil =>
-      app.summary2(summary.depositor.toOption, summary.datamanager.toOption, summary.age.toOption)
+      app.summary(summary.depositor.toOption, summary.datamanager.toOption, summary.age.toOption)
     case commandLine.reportCmd :: (error @ commandLine.reportCmd.errorCmd) :: Nil =>
-      app.createErrorReport2(error.depositor.toOption, error.datamanager.toOption, error.age.toOption)
+      app.createErrorReport(error.depositor.toOption, error.datamanager.toOption, error.age.toOption)
 
     case commandLine.reportCmdOld :: (full @ commandLine.reportCmdOld.fullCmd) :: Nil =>
-      app.createFullReport(full.depositor.toOption, full.datamanager.toOption, full.age.toOption)
+      app.createFullReportOld(full.depositor.toOption, full.datamanager.toOption, full.age.toOption)
     case commandLine.reportCmdOld :: (summary @ commandLine.reportCmdOld.summaryCmd) :: Nil =>
-      app.summary(summary.depositor.toOption, summary.datamanager.toOption, summary.age.toOption)
+      app.summaryOld(summary.depositor.toOption, summary.datamanager.toOption, summary.age.toOption)
     case commandLine.reportCmdOld :: (error @ commandLine.reportCmdOld.errorCmd) :: Nil =>
-      app.createErrorReport(error.depositor.toOption, error.datamanager.toOption, error.age.toOption)
+      app.createErrorReportOld(error.depositor.toOption, error.datamanager.toOption, error.age.toOption)
     case commandLine.reportCmdOld :: (raw @ commandLine.reportCmdOld.rawCmd) :: Nil =>
       app.createRawReport(raw.location())
 

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
@@ -44,7 +44,7 @@ object Command extends App with DebugEnhancedLogging {
 
   val result: Try[FeedBackMessage] = commandLine.subcommands match {
     case commandLine.reportCmd :: (full @ commandLine.reportCmd.fullCmd) :: Nil =>
-      app.createFullReport(full.depositor.toOption, full.datamanager.toOption, full.age.toOption)
+      app.createFullReport2(full.depositor.toOption, full.datamanager.toOption, full.age.toOption)
     case commandLine.reportCmd :: (summary @ commandLine.reportCmd.summaryCmd) :: Nil =>
       app.summary(summary.depositor.toOption, summary.datamanager.toOption, summary.age.toOption)
     case commandLine.reportCmd :: (error @ commandLine.reportCmd.errorCmd) :: Nil =>

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
@@ -48,10 +48,7 @@ object Command extends App with DebugEnhancedLogging {
     case commandLine.reportCmd :: (summary @ commandLine.reportCmd.summaryCmd) :: Nil =>
       app.summary(summary.depositor.toOption, summary.datamanager.toOption, summary.age.toOption)
     case commandLine.reportCmd :: (error @ commandLine.reportCmd.errorCmd) :: Nil =>
-      app.createErrorReport(error.depositor.toOption, error.datamanager.toOption, error.age.toOption)
-    case commandLine.reportCmd :: (raw @ commandLine.reportCmd.rawCmd) :: Nil =>
-      app.createRawReport(raw.location())
-
+      app.createErrorReport2(error.depositor.toOption, error.datamanager.toOption, error.age.toOption)
 
     case commandLine.reportCmdOld :: (full @ commandLine.reportCmdOld.fullCmd) :: Nil =>
       app.createFullReport(full.depositor.toOption, full.datamanager.toOption, full.age.toOption)

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
@@ -51,6 +51,17 @@ object Command extends App with DebugEnhancedLogging {
       app.createErrorReport(error.depositor.toOption, error.datamanager.toOption, error.age.toOption)
     case commandLine.reportCmd :: (raw @ commandLine.reportCmd.rawCmd) :: Nil =>
       app.createRawReport(raw.location())
+
+
+    case commandLine.reportCmdOld :: (full @ commandLine.reportCmdOld.fullCmd) :: Nil =>
+      app.createFullReport(full.depositor.toOption, full.datamanager.toOption, full.age.toOption)
+    case commandLine.reportCmdOld :: (summary @ commandLine.reportCmdOld.summaryCmd) :: Nil =>
+      app.summary(summary.depositor.toOption, summary.datamanager.toOption, summary.age.toOption)
+    case commandLine.reportCmdOld :: (error @ commandLine.reportCmdOld.errorCmd) :: Nil =>
+      app.createErrorReport(error.depositor.toOption, error.datamanager.toOption, error.age.toOption)
+    case commandLine.reportCmdOld :: (raw @ commandLine.reportCmdOld.rawCmd) :: Nil =>
+      app.createRawReport(raw.location())
+
     case (clean @ commandLine.cleanCmd) :: Nil =>
       val newState = for {
         state <- clean.newStateLabel.toOption

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
@@ -70,6 +70,8 @@ object Command extends App with DebugEnhancedLogging {
         Try { "Clean operation aborted by user" }
     case (syncFedora @ commandLine.`syncFedoraState`) :: Nil =>
       app.syncFedoraState(syncFedora.easyDatasetId())
+    case (deleteProps @ commandLine.deleteProperties) :: Nil =>
+      app.deleteProperties(deleteProps.location.toOption, deleteProps.uuid.toOption)
     case (loadProps @ commandLine.`loadProperties`) :: Nil =>
       if (loadProps.uuid.isDefined) app.loadSingleDepositProperties(loadProps.uuid())
       else if (loadProps.location.isDefined) app.loadDepositDirectoriesFromLocation(loadProps.location())

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
@@ -79,7 +79,10 @@ object Command extends App with DebugEnhancedLogging {
     case (syncFedora @ commandLine.`syncFedoraState`) :: Nil =>
       app.syncFedoraState(syncFedora.easyDatasetId())
     case (deleteProps @ commandLine.deleteProperties) :: Nil =>
-      app.deleteProperties(deleteProps.location.toOption, deleteProps.uuid.toOption)
+      if (deleteProps.location.isDefined) app.deletePropertiesFromLocation(deleteProps.location())
+      else if (deleteProps.uuid.isDefined) app.deleteProperties(deleteProps.uuid())
+           else if (deleteProps.all()) app.deleteAllProperties()
+                else Failure(new IllegalArgumentException("Not specified what to delete"))
     case (loadProps @ commandLine.`loadProperties`) :: Nil =>
       if (loadProps.uuid.isDefined) app.loadSingleDepositProperties(loadProps.uuid())
       else if (loadProps.location.isDefined) app.loadDepositDirectoriesFromLocation(loadProps.location())

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
@@ -70,6 +70,8 @@ object Command extends App with DebugEnhancedLogging {
         Try { "Clean operation aborted by user" }
     case (syncFedora @ commandLine.`syncFedoraState`) :: Nil =>
       app.syncFedoraState(syncFedora.easyDatasetId())
+    case (loadProps @ commandLine.loadProperties) :: Nil =>
+      app.loadSingleDepositProperties(loadProps.directory())
     case commandLine.runService :: Nil => runAsService(app)
     case _ => Failure(new IllegalArgumentException("Enter a valid subcommand"))
   }

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
@@ -27,8 +27,8 @@ import scala.util.{ Failure, Try }
 object Command extends App with DebugEnhancedLogging {
   type FeedBackMessage = String
 
-  val configuration = Configuration(Paths.get(System.getProperty("app.home")))
-  val commandLine: CommandLineOptions = new CommandLineOptions(args, configuration)
+  val configuration = Configuration.apply2(Paths.get(System.getProperty("app.home")))
+  val commandLine: CommandLineOptions = new CommandLineOptions(args, configuration.version)
   val app = new EasyManageDepositApp(configuration)
 
   @tailrec
@@ -82,7 +82,7 @@ object Command extends App with DebugEnhancedLogging {
     }
 
   private def runAsService(app: EasyManageDepositApp): Try[FeedBackMessage] = Try {
-    val service = new EasyManageDepositService(configuration.properties.getString("daemon.http.port").toInt, Map(
+    val service = new EasyManageDepositService(configuration.serverPort, Map(
       "/" -> new EasyManageDepositServlet(app, configuration.version),
     ))
     Runtime.getRuntime.addShutdownHook(new Thread("service-shutdown") {

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
@@ -70,8 +70,8 @@ object Command extends App with DebugEnhancedLogging {
         Try { "Clean operation aborted by user" }
     case (syncFedora @ commandLine.`syncFedoraState`) :: Nil =>
       app.syncFedoraState(syncFedora.easyDatasetId())
-    case (loadProps @ commandLine.loadProperties) :: Nil =>
-      app.loadSingleDepositProperties(loadProps.directory())
+    case (loadProps @ commandLine.`loadProperties`) :: Nil =>
+      app.loadSingleDepositProperties(loadProps.uuid())
     case commandLine.runService :: Nil => runAsService(app)
     case _ => Failure(new IllegalArgumentException("Enter a valid subcommand"))
   }

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
@@ -71,7 +71,9 @@ object Command extends App with DebugEnhancedLogging {
     case (syncFedora @ commandLine.`syncFedoraState`) :: Nil =>
       app.syncFedoraState(syncFedora.easyDatasetId())
     case (loadProps @ commandLine.`loadProperties`) :: Nil =>
-      app.loadSingleDepositProperties(loadProps.uuid())
+      if (loadProps.uuid.isDefined) app.loadSingleDepositProperties(loadProps.uuid())
+      else if (loadProps.location.isDefined) app.loadDepositDirectoriesFromLocation(loadProps.location())
+           else app.loadDepositDirectoriesFromAllLocations()
     case commandLine.runService :: Nil => runAsService(app)
     case _ => Failure(new IllegalArgumentException("Enter a valid subcommand"))
   }
@@ -98,6 +100,5 @@ object Command extends App with DebugEnhancedLogging {
     Thread.currentThread.join()
     "Service terminated normally."
   }
-
 }
 

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
@@ -27,7 +27,7 @@ import scala.util.{ Failure, Try }
 object Command extends App with DebugEnhancedLogging {
   type FeedBackMessage = String
 
-  val configuration = Configuration.apply2(Paths.get(System.getProperty("app.home")))
+  val configuration = Configuration(Paths.get(System.getProperty("app.home")))
   val commandLine: CommandLineOptions = new CommandLineOptions(args, configuration.version)
   val app = new EasyManageDepositApp(configuration)
 

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/Command.scala
@@ -46,7 +46,7 @@ object Command extends App with DebugEnhancedLogging {
     case commandLine.reportCmd :: (full @ commandLine.reportCmd.fullCmd) :: Nil =>
       app.createFullReport2(full.depositor.toOption, full.datamanager.toOption, full.age.toOption)
     case commandLine.reportCmd :: (summary @ commandLine.reportCmd.summaryCmd) :: Nil =>
-      app.summary(summary.depositor.toOption, summary.datamanager.toOption, summary.age.toOption)
+      app.summary2(summary.depositor.toOption, summary.datamanager.toOption, summary.age.toOption)
     case commandLine.reportCmd :: (error @ commandLine.reportCmd.errorCmd) :: Nil =>
       app.createErrorReport2(error.depositor.toOption, error.datamanager.toOption, error.age.toOption)
 

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
@@ -134,6 +134,7 @@ class CommandLineOptions(args: Array[String], version: String) extends ScallopCo
     val single: ScallopOption[Boolean] = opt("single", descr = "The directory is a single deposit")
     val directory: ScallopOption[Path] = trailArg("directory", descr = "The directory from which to load the deposit properties", required = true)
   }
+  addSubcommand(loadProperties)
 
   val runService = new Subcommand("run-service") {
     descr(

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
@@ -133,6 +133,7 @@ class CommandLineOptions(args: Array[String], version: String) extends ScallopCo
     descr("Loads the deposit.properties from the specified directory in the database. By default the directory is expected to contain subdirectories that are deposits. To load one deposit, use the --single option" )
     val single: ScallopOption[Boolean] = opt("single", descr = "The directory is a single deposit")
     val directory: ScallopOption[Path] = trailArg("directory", descr = "The directory from which to load the deposit properties", required = true)
+    footer(SUBCOMMAND_SEPARATOR)
   }
   addSubcommand(loadProperties)
 

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
@@ -37,6 +37,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
        |            [-l, --new-state-label <state>] [-n, --new-state-description <description>] \\
        |            [-f, --force] [-o, --output] [--do-update] [<depositor>]
        |  $printedName sync-fedora-state <easy-dataset-id>
+       |  $printedName run-service
      """.stripMargin
   version(s"$printedName v${ configuration.version }")
   banner(
@@ -127,6 +128,14 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
     footer(SUBCOMMAND_SEPARATOR)
   }
   addSubcommand(syncFedoraState)
+
+  val runService = new Subcommand("run-service") {
+    descr(
+      "Starts EASY Manage Deposit as a daemon")
+    footer(SUBCOMMAND_SEPARATOR)
+  }
+  addSubcommand(runService)
+
 
   footer("")
   verify()

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
@@ -129,6 +129,12 @@ class CommandLineOptions(args: Array[String], version: String) extends ScallopCo
   }
   addSubcommand(syncFedoraState)
 
+  val loadProperties = new Subcommand("load-properties") {
+    descr("Loads the deposit.properties from the specified directory in the database. By default the directory is expected to contain subdirectories that are deposits. To load one deposit, use the --single option" )
+    val single: ScallopOption[Boolean] = opt("single", descr = "The directory is a single deposit")
+    val directory: ScallopOption[Path] = trailArg("directory", descr = "The directory from which to load the deposit properties", required = true)
+  }
+
   val runService = new Subcommand("run-service") {
     descr(
       "Starts EASY Manage Deposit as a daemon")

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
@@ -147,7 +147,7 @@ class CommandLineOptions(args: Array[String], version: String) extends ScallopCo
     }
     addSubcommand(rawCmd)
   }
-  addSubcommand(reportCmd)
+  addSubcommand(reportCmdOld)
 
   val cleanCmd = new Subcommand("clean") {
     val depositor: ScallopOption[DepositorId] = trailArg("depositor", required = false)

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
@@ -181,6 +181,8 @@ class CommandLineOptions(args: Array[String], version: String) extends ScallopCo
     descr("Deletes selected properties from the databse")
     val uuid: ScallopOption[String] = trailArg("uuid", descr = "Only load this deposit", required = false)
     val location: ScallopOption[String] = opt("location", descr = "Only delete deposits from this location (one of: SWORD2, INGEST_FLOW, INGEST_FLOW_ARCHIVED")
+    val all: ScallopOption[Boolean] = opt("all", descr = "Delete all properties")
+    mutuallyExclusive(uuid, location, all)
     footer(SUBCOMMAND_SEPARATOR)
   }
   addSubcommand(deleteProperties)

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
@@ -129,6 +129,14 @@ class CommandLineOptions(args: Array[String], version: String) extends ScallopCo
   }
   addSubcommand(syncFedoraState)
 
+  val deleteProperties = new Subcommand("delete-properties") {
+    descr("Deletes selected properties from the databse")
+    val uuid: ScallopOption[String] = trailArg("uuid", descr = "Only load this deposit", required = false)
+    val location: ScallopOption[String] = opt("location", descr = "Only delete deposits from this location (one of: SWORD2, INGEST_FLOW, INGEST_FLOW_ARCHIVED")
+    footer(SUBCOMMAND_SEPARATOR)
+  }
+  addSubcommand(deleteProperties)
+
   val loadProperties = new Subcommand("load-properties") {
     descr("(Re-)loads the deposit properties into the database, overwriting the current records")
     val uuid: ScallopOption[String] = trailArg("uuid", descr = "Only load this deposit", required = false)

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
@@ -130,8 +130,9 @@ class CommandLineOptions(args: Array[String], version: String) extends ScallopCo
   addSubcommand(syncFedoraState)
 
   val loadProperties = new Subcommand("load-properties") {
-    descr("(Re-)loads the deposit properties into the database, overwriting the current records" )
+    descr("(Re-)loads the deposit properties into the database, overwriting the current records")
     val uuid: ScallopOption[String] = trailArg("uuid", descr = "Only load this deposit", required = false)
+    val location: ScallopOption[String] = opt("location", descr = "Only load deposits from this location (one of: SWORD2, INGEST_FLOW, INGEST_FLOW_ARCHIVED")
     footer(SUBCOMMAND_SEPARATOR)
   }
   addSubcommand(loadProperties)
@@ -142,7 +143,6 @@ class CommandLineOptions(args: Array[String], version: String) extends ScallopCo
     footer(SUBCOMMAND_SEPARATOR)
   }
   addSubcommand(runService)
-
 
   footer("")
   verify()

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
@@ -101,6 +101,54 @@ class CommandLineOptions(args: Array[String], version: String) extends ScallopCo
   }
   addSubcommand(reportCmd)
 
+  val reportCmdOld = new Subcommand("report-old") {
+
+    val fullCmd = new Subcommand("full") {
+      val depositor: ScallopOption[DepositorId] = trailArg("depositor", required = false)
+      val datamanager: ScallopOption[Datamanager] = opt("datamanager", short = 'm',
+        descr = "Only report on the deposits that are assigned to this datamanager.")
+      val age: ScallopOption[Age] = opt[Age](name = "age", short = 'a', validate = 0 <=,
+        descr = "Only report on the deposits that are less than n days old. An age argument of n=0 days corresponds to 0<=n<1. If this argument is not provided, all deposits will be reported on.")
+      descr("creates a full report for a depositor and/or datamanager")
+      footer(SUBCOMMAND_SEPARATOR)
+    }
+    addSubcommand(fullCmd)
+
+    val summaryCmd = new Subcommand("summary") {
+      val depositor: ScallopOption[DepositorId] = trailArg("depositor", required = false)
+      val datamanager: ScallopOption[Datamanager] = opt("datamanager", short = 'm',
+        descr = "Only report on the deposits that are assigned to this datamanager.")
+      val age: ScallopOption[Age] = opt[Age](name = "age", short = 'a', validate = 0 <=,
+        descr = "Only report on the deposits that are less than n days old. An age argument of n=0 days corresponds to 0<=n<1. If this argument is not provided, all deposits will be reported on.")
+      descr("creates a summary report for a depositor and/or datamanager")
+      footer(SUBCOMMAND_SEPARATOR)
+    }
+    addSubcommand(summaryCmd)
+
+    val errorCmd = new Subcommand("error") {
+      val depositor: ScallopOption[DepositorId] = trailArg("depositor", required = false)
+      val datamanager: ScallopOption[Datamanager] = opt("datamanager", short = 'm',
+        descr = "Only report on the deposits that are assigned to this datamanager.")
+      val age: ScallopOption[Age] = opt[Age](name = "age", short = 'a', validate = 0 <=,
+        descr = "Only report on the deposits that are less than n days old. An age argument of n=0 days corresponds to 0<=n<1. If this argument is not provided, all deposits will be reported on.")
+      descr("creates a report displaying all failed, rejected and invalid deposits for a depositor and/or datamanager")
+      footer(SUBCOMMAND_SEPARATOR)
+    }
+    addSubcommand(errorCmd)
+
+    val rawCmd = new Subcommand("raw") {
+      val location: ScallopOption[Path] = trailArg[Path](name = "location")
+
+      validatePathExists(location)
+      validatePathIsDirectory(location)
+
+      descr("creates a report containing all content of deposit.properties without inferring any properties")
+      footer(SUBCOMMAND_SEPARATOR)
+    }
+    addSubcommand(rawCmd)
+  }
+  addSubcommand(reportCmd)
+
   val cleanCmd = new Subcommand("clean") {
     val depositor: ScallopOption[DepositorId] = trailArg("depositor", required = false)
     val dataOnly: ScallopOption[Boolean] = opt[Boolean](default = Some(false), descr = "If specified, the deposit.properties and the container file of the deposit are not deleted")

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
@@ -130,9 +130,8 @@ class CommandLineOptions(args: Array[String], version: String) extends ScallopCo
   addSubcommand(syncFedoraState)
 
   val loadProperties = new Subcommand("load-properties") {
-    descr("Loads the deposit.properties from the specified directory in the database. By default the directory is expected to contain subdirectories that are deposits. To load one deposit, use the --single option" )
-    val single: ScallopOption[Boolean] = opt("single", descr = "The directory is a single deposit")
-    val directory: ScallopOption[Path] = trailArg("directory", descr = "The directory from which to load the deposit properties", required = true)
+    descr("(Re-)loads the deposit properties into the database, overwriting the current records" )
+    val uuid: ScallopOption[String] = trailArg("uuid", descr = "Only load this deposit", required = false)
     footer(SUBCOMMAND_SEPARATOR)
   }
   addSubcommand(loadProperties)

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
@@ -26,7 +26,7 @@ class CommandLineOptions(args: Array[String], version: String) extends ScallopCo
   editBuilder(_.setHelpWidth(110))
   printedName = "easy-manage-deposit"
   private val SUBCOMMAND_SEPARATOR = "---\n"
-  val description: String = s"""Manage DANS deposit directories."""
+  val description: String = s"""Manage the deposit area."""
   val synopsis: String =
     s"""
        |  $printedName report full [-a, --age <n>] [-m, --datamanager <uid>] [<depositor>]

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/CommandLineOptions.scala
@@ -21,7 +21,7 @@ import org.rogach.scallop.{ ScallopConf, ScallopOption, Subcommand, ValueConvert
 import java.nio.file.Path
 import scala.language.{ postfixOps, reflectiveCalls }
 
-class CommandLineOptions(args: Array[String], configuration: Configuration) extends ScallopConf(args) {
+class CommandLineOptions(args: Array[String], version: String) extends ScallopConf(args) {
   appendDefaultToDescription = true
   editBuilder(_.setHelpWidth(110))
   printedName = "easy-manage-deposit"
@@ -39,7 +39,7 @@ class CommandLineOptions(args: Array[String], configuration: Configuration) exte
        |  $printedName sync-fedora-state <easy-dataset-id>
        |  $printedName run-service
      """.stripMargin
-  version(s"$printedName v${ configuration.version }")
+  version(s"$printedName v$version")
   banner(
     s"""
        |  $description

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/Configuration.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/Configuration.scala
@@ -25,8 +25,6 @@ import java.net.{ URI, URL }
 import java.nio.file.{ Files, Path, Paths }
 import scala.io.Source
 
-case class Configuration(version: String, properties: PropertiesConfiguration)
-
 case class Configuration2(version: String,
                           serverPort: Int,
                           databaseUrl: URI,
@@ -43,20 +41,7 @@ case class Configuration2(version: String,
 
 object Configuration {
 
-  def apply(home: Path): Configuration = {
-    val cfgPath = Seq(
-      Paths.get(s"/etc/opt/dans.knaw.nl/easy-manage-deposit/"),
-      home.resolve("cfg"))
-      .find(Files.exists(_))
-      .getOrElse { throw new IllegalStateException("No configuration directory found") }
-
-    new Configuration(
-      version = managed(Source.fromFile(home.resolve("bin/version").toFile)).acquireAndGet(_.mkString),
-      properties = new PropertiesConfiguration(cfgPath.resolve("application.properties").toFile)
-    )
-  }
-
-  def apply2(home: Path): Configuration2 = {
+  def apply(home: Path): Configuration2 = {
     val cfgPath = Seq(
       Paths.get(s"/etc/opt/dans.knaw.nl/easy-manage-deposit/"),
       home.resolve("cfg"))

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/Configuration.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/Configuration.scala
@@ -15,13 +15,31 @@
  */
 package nl.knaw.dans.easy.managedeposit
 
+import com.yourmediashelf.fedora.client.{ FedoraClient, FedoraCredentials }
 import org.apache.commons.configuration.PropertiesConfiguration
 import resource.managed
+import nl.knaw.dans.lib.string._
+import scala.collection.JavaConverters._
 
+import java.net.{ URI, URL }
 import java.nio.file.{ Files, Path, Paths }
 import scala.io.Source
 
 case class Configuration(version: String, properties: PropertiesConfiguration)
+
+case class Configuration2(version: String,
+                          serverPort: Int,
+                          databaseUrl: URI,
+                          databaseUser: String,
+                          databasePassword: String,
+                          databaseDriver: String,
+                          fedora: Fedora,
+                          sword2DepositsDir: Path,
+                          ingestFlowInbox: Path,
+                          ingestFlowInboxArchived: Option[Path],
+                          landingPageBaseUrl: URI,
+                          dansDoiPrefixes: List[String])
+
 
 object Configuration {
 
@@ -36,5 +54,37 @@ object Configuration {
       version = managed(Source.fromFile(home.resolve("bin/version").toFile)).acquireAndGet(_.mkString),
       properties = new PropertiesConfiguration(cfgPath.resolve("application.properties").toFile)
     )
+  }
+
+  def apply2(home: Path): Configuration2 = {
+    val cfgPath = Seq(
+      Paths.get(s"/etc/opt/dans.knaw.nl/easy-manage-deposit/"),
+      home.resolve("cfg"))
+      .find(Files.exists(_))
+      .getOrElse { throw new IllegalStateException("No configuration directory found") }
+    val properties = new PropertiesConfiguration() {
+      setDelimiterParsingDisabled(true)
+      load(cfgPath.resolve("application.properties").toFile)
+    }
+    val fedoraCredentials = new FedoraCredentials(
+      new URL(properties.getString("fedora.url")),
+      properties.getString("fedora.user"),
+      properties.getString("fedora.password"))
+
+    Configuration2(
+      version = managed(Source.fromFile(home.resolve("bin/version").toFile)).acquireAndGet(_.mkString),
+      serverPort = properties.getInt("daemon.http.port"),
+      databaseUrl = new URI(properties.getString("database.url")),
+      databaseUser = properties.getString("database.user"),
+      databasePassword = properties.getString("database.password"),
+      databaseDriver = properties.getString("database.driver"),
+      fedora = new Fedora(new FedoraClient(fedoraCredentials)),
+      sword2DepositsDir = Paths.get(properties.getString("easy-sword2")),
+      ingestFlowInbox = Paths.get(properties.getString("easy-ingest-flow-inbox")),
+      ingestFlowInboxArchived = properties.getString("easy-ingest-flow-inbox-archived").toOption.map(Paths.get(_)).filter(Files.exists(_)),
+      landingPageBaseUrl = new URI(properties.getString("landing-pages.base-url")),
+      dansDoiPrefixes = properties.getList("dans-doi.prefixes")
+      .asScala.toList
+      .map(prefix => prefix.asInstanceOf[String]))
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/Configuration.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/Configuration.scala
@@ -25,7 +25,7 @@ import java.net.{ URI, URL }
 import java.nio.file.{ Files, Path, Paths }
 import scala.io.Source
 
-case class Configuration2(version: String,
+case class Configuration(version: String,
                           serverPort: Int,
                           databaseUrl: URI,
                           databaseUser: String,
@@ -38,10 +38,9 @@ case class Configuration2(version: String,
                           landingPageBaseUrl: URI,
                           dansDoiPrefixes: List[String])
 
-
 object Configuration {
 
-  def apply(home: Path): Configuration2 = {
+  def apply(home: Path): Configuration = {
     val cfgPath = Seq(
       Paths.get(s"/etc/opt/dans.knaw.nl/easy-manage-deposit/"),
       home.resolve("cfg"))
@@ -56,7 +55,7 @@ object Configuration {
       properties.getString("fedora.user"),
       properties.getString("fedora.password"))
 
-    Configuration2(
+    Configuration(
       version = managed(Source.fromFile(home.resolve("bin/version").toFile)).acquireAndGet(_.mkString),
       serverPort = properties.getInt("daemon.http.port"),
       databaseUrl = new URI(properties.getString("database.url")),

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/Database.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/Database.scala
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.managedeposit
+
+import nl.knaw.dans.lib.error.TryExtensions
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import org.apache.commons.dbcp2.BasicDataSource
+import resource.managed
+
+import java.net.URI
+import java.sql.Connection
+import javax.sql.DataSource
+import scala.util.control.NonFatal
+import scala.util.{ Failure, Try }
+
+class Database(url: URI, user: String, password: String, driver: String) extends DebugEnhancedLogging {
+  type ConnectionPool = DataSource with AutoCloseable
+
+  private var pool: ConnectionPool = _
+
+  protected def createConnectionPool: ConnectionPool = {
+    val source = new BasicDataSource
+    source.setDriverClassName(driver)
+    source.setUrl(url.toASCIIString)
+    source.setUsername(user)
+    source.setPassword(password)
+    source
+  }
+
+  def initConnectionPool(): Try[Unit] = Try {
+    logger.info("Creating database connection ...")
+    pool = createConnectionPool
+    logger.info(s"Database connected with URL = ${url.toASCIIString}, user = $user, password = ****")
+  }
+
+  def closeConnectionPool(): Try[Unit] = Try {
+    logger.info("Closing database connection ...")
+    pool.close()
+    logger.info("Database connection closed")
+  }
+
+  /**
+   * Performs a database transaction with the function argument. Given the `Connection` in
+   * `actionFunc`, the user can create and execute SQL statements and queries, which must result in
+   * a `Try[T]`. If the result of `actionFunc` is a `Success`, the transaction will be completed by
+   * committing the results to the database. If the result of `actionFunc` is a `Failure`,
+   * the changes made during this transaction are rolled back.
+   * The result (either `Success` or `Failure`) will then be returned.
+   *
+   * '''Note:''' the user is not supposed to close the connection, to commit or rollback any changes
+   * in `actionFunc` itself.
+   *
+   * @param actionFunc the actions to be performed on the database given the `Connection`
+   * @tparam T the return type of the performed actions
+   * @return `Success` if the actions performed on the database were successful; `Failure` otherwise
+   */
+  def doTransaction[T](actionFunc: Connection => Try[T]): Try[T] = {
+    managed(pool.getConnection)
+      .map(connection => {
+        connection.setAutoCommit(false)
+        val savepoint = connection.setSavepoint()
+
+        actionFunc(connection)
+          .doIfSuccess(_ => {
+            connection.commit()
+            connection.setAutoCommit(true)
+          })
+          .recoverWith {
+            case NonFatal(e) => Try { connection.rollback(savepoint) }.flatMap(_ => Failure(e))
+          }
+      })
+      .tried
+      .flatten
+  }
+}

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/Database.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/Database.scala
@@ -74,7 +74,7 @@ class Database(url: URI, user: String, password: String, driver: String) extends
         connection.setAutoCommit(false)
         val savepoint = connection.setSavepoint()
 
-        debug("Calling transation function")
+        debug("Calling transaction function")
         actionFunc(connection)
           .doIfSuccess(_ => {
             connection.commit()

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/Database.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/Database.scala
@@ -41,7 +41,7 @@ class Database(url: URI, user: String, password: String, driver: String) extends
   }
 
   def initConnectionPool(): Try[Unit] = Try {
-    logger.info("Creating database connection ...")
+    logger.info("Creating database connection ... ")
     pool = createConnectionPool
     logger.info(s"Database connected with URL = ${url.toASCIIString}, user = $user, password = ****")
   }
@@ -68,11 +68,13 @@ class Database(url: URI, user: String, password: String, driver: String) extends
    * @return `Success` if the actions performed on the database were successful; `Failure` otherwise
    */
   def doTransaction[T](actionFunc: Connection => Try[T]): Try[T] = {
+    trace(())
     managed(pool.getConnection)
       .map(connection => {
         connection.setAutoCommit(false)
         val savepoint = connection.setSavepoint()
 
+        debug("Calling transation function")
         actionFunc(connection)
           .doIfSuccess(_ => {
             connection.commit()

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositInformation.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositInformation.scala
@@ -34,6 +34,7 @@ case class DepositInformation(depositId: DepositId,
                               location: String,
                               bagDirName: String,
                               datamanager: Datamanager,
+                              hasBag: Boolean = true,
                              )
                              (implicit dansDoiPrefixes: List[String]) {
 

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositManager.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositManager.scala
@@ -22,6 +22,7 @@ import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.apache.commons.io.FileUtils
 import org.apache.commons.lang.{ BooleanUtils, StringUtils }
+import org.joda.time.format.{ DateTimeFormatter, ISODateTimeFormat }
 import org.joda.time.{ DateTime, DateTimeZone, Duration }
 import resource.managed
 

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositManager.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositManager.scala
@@ -22,7 +22,6 @@ import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.apache.commons.io.FileUtils
 import org.apache.commons.lang.{ BooleanUtils, StringUtils }
-import org.joda.time.format.{ DateTimeFormatter, ISODateTimeFormat }
 import org.joda.time.{ DateTime, DateTimeZone, Duration }
 import resource.managed
 

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositPropertiesTable.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositPropertiesTable.scala
@@ -87,13 +87,13 @@ class DepositPropertiesTable(database: Database)(implicit val dansDoiPrefixes: L
           action(
             DepositInformation(
               depositId = resultSet.getString("uuid"),
-              doiIdentifier = props.getString("identifier.doi"),
+              doiIdentifier = props.getString("identifier.doi", "n/a"),
               dansDoiRegistered = Option(BooleanUtils.toBoolean(props.getString("identifier.dans-doi.registered"))),
               fedoraIdentifier = props.getString("identifier.fedora", "n/a"),
               depositor = resultSet.getString("depositor_user_id"),
               state = State.toState(resultSet.getString("state_label")).getOrElse(State.UNKNOWN),
               description = props.getString("state.description", "n/a"),
-              creationTimestamp = props.getString("creation.timestamp"),
+              creationTimestamp = props.getString("creation.timestamp", "n/a"),
               numberOfContinuedDeposits = -1, // TODO: remove from report
               storageSpace = resultSet.getLong("storage_size_in_bytes"),
               lastModified = resultSet.getTimestamp("last_modified").toString,

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositPropertiesTable.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositPropertiesTable.scala
@@ -19,6 +19,8 @@ import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.apache.commons.lang.BooleanUtils
+import org.joda.time.format.{ DateTimeFormatter, ISODateTimeFormat }
+import org.joda.time.{ DateTime, DateTimeZone }
 import resource.managed
 
 import java.io.StringReader
@@ -28,6 +30,7 @@ import scala.util.Try
 import scala.util.control.NonFatal
 
 class DepositPropertiesTable(database: Database)(implicit val dansDoiPrefixes: List[String]) extends DebugEnhancedLogging {
+  private val dateTimeFormatter: DateTimeFormatter = ISODateTimeFormat.dateTime()
 
   def save(uuid: String, props: PropertiesConfiguration, propsText: String, lastModified: Long, sizeInBytes: Long, location: String): Try[Unit] = {
     trace(uuid, props, propsText, sizeInBytes, location)
@@ -94,9 +97,9 @@ class DepositPropertiesTable(database: Database)(implicit val dansDoiPrefixes: L
               state = State.toState(resultSet.getString("state_label")).getOrElse(State.UNKNOWN),
               description = props.getString("state.description", "n/a"),
               creationTimestamp = props.getString("creation.timestamp", "n/a"),
-              numberOfContinuedDeposits = -1, // TODO: remove from report
+              numberOfContinuedDeposits = -1, // TODO: add to database
               storageSpace = resultSet.getLong("storage_size_in_bytes"),
-              lastModified = resultSet.getTimestamp("last_modified").toString,
+              lastModified = new DateTime(resultSet.getTimestamp("last_modified")).withZone(DateTimeZone.UTC).toString(dateTimeFormatter),
               origin = props.getString("deposit.origin", "n/a"),
               location = resultSet.getString("location"),
               bagDirName = props.getString("bag-store.bag-name", "n/a"),

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositPropertiesTable.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositPropertiesTable.scala
@@ -1,0 +1,146 @@
+/**
+ * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.managedeposit
+
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import org.apache.commons.configuration.PropertiesConfiguration
+import org.joda.time.DateTime
+import resource.managed
+
+import java.io.{ StringReader, StringWriter }
+import java.sql.{ Connection, Timestamp }
+import scala.collection.mutable
+import scala.util.Try
+
+class DepositPropertiesTable(database: Database) extends DebugEnhancedLogging {
+  private val selectQuery =
+    """
+      |SELECT
+      |  uuid,
+      |  last_modified,
+      |  properties,
+      |  status_label,
+      |  depositor_user_id,
+      |  datamanager
+      |FROM deposit_properties
+      |WHERE uuid = ?
+      |""".stripMargin
+
+  private val insertQuery =
+    """
+      |INSERT INTO deposit_properties (
+      |  uuid,
+      |  last_modified,
+      |  properties,
+      |  status_label,
+      |  depositor_user_id,
+      |  datamanager)
+      |VALUES (?, ?, ?, ?, ?, ?);
+        """.stripMargin
+
+  private val updateQuery =
+    """
+      |UPDATE deposit_properties
+      |SET
+      |  last_modified = ?,
+      |  properties = ?,
+      |  status_label = ?,
+      |  depositor_user_id = ?,
+      |  datamanager = ?
+      |WHERE uuid = ?
+        """.stripMargin
+
+  def save(uuid: String, props: PropertiesConfiguration): Try[Unit] = {
+    trace(uuid, props)
+    for {
+      optPropString <- database.doTransaction(implicit c => select(uuid))
+      _ = debug(s"Found result for $uuid?: ${ optPropString.isDefined }")
+      _ <- optPropString
+        .map(_ => database.doTransaction(implicit c => update(uuid, props)))
+        .getOrElse(database.doTransaction(implicit c => insert(uuid, props)))
+    } yield ()
+  }
+
+  def get(uuid: String): Try[Option[PropertiesConfiguration]] = {
+    for {
+      optText <- database.doTransaction(implicit c => select(uuid))
+      optProps = optText.map {
+        t => {
+          new PropertiesConfiguration() {
+            setDelimiterParsingDisabled(true)
+            load(new StringReader(t))
+          }
+        }
+      }
+    }
+    yield optProps
+  }
+
+  private def select(uuid: String)(implicit c: Connection): Try[Option[String]] = {
+    trace(uuid)
+    managed(c.prepareStatement(selectQuery))
+      .map(ps => {
+        ps.setString(1, uuid)
+        ps.executeQuery()
+      }).map(
+      r => {
+        val ss = new mutable.ListBuffer[String]()
+
+        while (r.next()) {
+          ss.append(r.getString("properties"))
+        }
+        if (ss.size > 1) throw new IllegalStateException(s"Found ${ ss.size } deposits with the same UUID")
+        ss.headOption
+      }).tried
+  }
+
+  private def insert(uuid: String, props: PropertiesConfiguration)(implicit c: Connection): Try[Unit] = {
+    trace(uuid, props)
+
+    val sw = new StringWriter()
+    props.save(sw)
+    debug(s"Properties to save: ${sw.toString}")
+
+    managed(c.prepareStatement(insertQuery))
+      .map(ps => {
+        ps.setString(1, uuid)
+        ps.setTimestamp(2, new Timestamp(System.currentTimeMillis()))
+        ps.setString(3, sw.toString)
+        ps.setString(4, props.getString("status.label"))
+        ps.setString(5, props.getString("depositor.userId"))
+        ps.setString(6, props.getString("curation.datamanager.userId", ""))
+        ps.executeUpdate()
+      }).tried.map(_ => ())
+  }
+
+  private def update(uuid: String, props: PropertiesConfiguration)(implicit c: Connection): Try[Unit] = {
+    trace(uuid, props)
+
+    val sw = new StringWriter()
+    props.save(sw)
+
+    managed(c.prepareStatement(updateQuery))
+      .map(ps => {
+        ps.setTimestamp(1, new Timestamp(System.currentTimeMillis()))
+        ps.setString(2, sw.toString)
+        ps.setString(3, props.getString("status.label"))
+        ps.setString(4, props.getString("depositor.userId"))
+        ps.setString(5, props.getString("curation.datamanager.userId", ""))
+        ps.setString(6, uuid)
+        ps.executeUpdate()
+      }).tried.map(_ => ())
+  }
+}

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositPropertiesTable.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/DepositPropertiesTable.scala
@@ -49,12 +49,16 @@ class DepositPropertiesTable(database: Database)(implicit val dansDoiPrefixes: L
     database.doTransaction(implicit c => selectUuid(uuid))
   }
 
-  def deleteProperties(optLocation: Option[String], optUuid: Option[String]): Try[Unit] = {
-    database.doTransaction(implicit c => {
-      if (optLocation.isDefined) deleteLocation(optLocation.get)
-      else if (optUuid.isDefined) deleteUUid(optUuid.get)
-           else deleteAll()
-    })
+  def deleteAllProperties(): Try[Unit] = {
+    database.doTransaction(implicit c => deleteAll())
+  }
+
+  def deletePropertiesFromLocation(location: String): Try[Unit] = {
+    database.doTransaction(implicit c => deleteLocation(location))
+  }
+
+  def deleteProperties(uuid: String): Try[Unit] = {
+    database.doTransaction(implicit c => deleteUUid(uuid))
   }
 
   def processDepositInformation(filterStates: List[State] = List.empty,

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
@@ -47,9 +47,9 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
     new DepositPropertiesTable(database)
   }
 
-  def saveDepositProperties(uuid: String, props: PropertiesConfiguration, propsText: String, sizeInBytes: Long, location: String): Try[Unit] = {
+  def saveDepositProperties(uuid: String, props: PropertiesConfiguration, propsText: String, lastModified: Long, sizeInBytes: Long, location: String): Try[Unit] = {
     trace(uuid, props, propsText)
-    propsTable.save(uuid, props, propsText, sizeInBytes, location)
+    propsTable.save(uuid, props, propsText, lastModified, sizeInBytes, location)
   }
 
   def getDepositProperties(uuid: String): Try[Option[String]] = {
@@ -108,10 +108,11 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
       val propsFile = dir.resolve("deposit.properties")
       val uuid = dir.getFileName.toString
       val propsString = FileUtils.readFileToString(propsFile.toFile, StandardCharsets.UTF_8)
+      val lastModified = Files.getLastModifiedTime(propsFile).toMillis
       val sizeInBytes = FileUtils.sizeOfDirectory(dir.toFile)
       val location = getLocationFromPath(dir).getOrElse("UNKOWN")
       readDepositProperties(propsString)
-        .flatMap(p => saveDepositProperties(uuid, p, propsString, sizeInBytes, location))
+        .flatMap(p => saveDepositProperties(uuid, p, propsString, lastModified, sizeInBytes, location))
         .map(_ => logger.info(s"Loaded $uuid"))
         .unsafeGetOrThrow
     }

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
@@ -255,7 +255,7 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
     } yield depositInformation
   }
 
-  def summary(depositor: Option[DepositorId], datamanager: Option[Datamanager], age: Option[Age]): Try[String] = Try {
+  def summaryOld(depositor: Option[DepositorId], datamanager: Option[Datamanager], age: Option[Age]): Try[String] = Try {
     val sword2Deposits = collectDataFromDepositsDir(configuration.sword2DepositsDir, depositor, datamanager, age, "SWORD2")
     val ingestFlowDeposits = collectDataFromDepositsDir(configuration.ingestFlowInbox, depositor, datamanager, age, "INGEST_FLOW")
     val ingestFlowArchivedDeposits = configuration.ingestFlowInboxArchived.map(collectDataFromDepositsDir(_, depositor, datamanager, age, "INGEST_FLOW_ARCHIVED")).getOrElse(Seq.empty)
@@ -263,7 +263,7 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
     "End of summary report."
   }
 
-  def summary2(depositor: Option[DepositorId], datamanager: Option[Datamanager], age: Option[Age]): Try[String] = Try {
+  def summary(depositor: Option[DepositorId], datamanager: Option[Datamanager], age: Option[Age]): Try[String] = Try {
     outputSummary(depositor, datamanager, age)(Console.out)
     "End of summary report."
   }
@@ -318,7 +318,7 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
                    else formatSize(1, "B")
   }
 
-  def createFullReport(depositor: Option[DepositorId], datamanager: Option[Datamanager], age: Option[Age]): Try[String] = Try {
+  def createFullReportOld(depositor: Option[DepositorId], datamanager: Option[Datamanager], age: Option[Age]): Try[String] = Try {
     val sword2Deposits = collectDataFromDepositsDir(configuration.sword2DepositsDir, depositor, datamanager, age, "SWORD2")
     val ingestFlowDeposits = collectDataFromDepositsDir(configuration.ingestFlowInbox, depositor, datamanager, age, "INGEST_FLOW")
     val ingestFlowArchivedDeposits = configuration.ingestFlowInboxArchived.map(collectDataFromDepositsDir(_, depositor, datamanager, age, "INGEST_FLOW_ARCHIVED")).getOrElse(Seq.empty)
@@ -326,7 +326,7 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
     "End of full report."
   }
 
-  def createFullReport2(depositor: Option[DepositorId], datamanager: Option[Datamanager], age: Option[Age]): Try[String] = {
+  def createFullReport(depositor: Option[DepositorId], datamanager: Option[Datamanager], age: Option[Age]): Try[String] = {
     managed(new ReportWriter()(Console.out)).map(propsTable.processDepositInformation(
       filterStates = List.empty,
       depositor,
@@ -334,7 +334,7 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
       age)).map(_ => "End of full report.").tried
   }
 
-  def createErrorReport(depositor: Option[DepositorId], datamanager: Option[Datamanager], age: Option[Age]): Try[String] = Try {
+  def createErrorReportOld(depositor: Option[DepositorId], datamanager: Option[Datamanager], age: Option[Age]): Try[String] = Try {
     val sword2Deposits = collectDataFromDepositsDir(configuration.sword2DepositsDir, depositor, datamanager, age, "SWORD2")
     val ingestFlowDeposits = collectDataFromDepositsDir(configuration.ingestFlowInbox, depositor, datamanager, age, "INGEST_FLOW")
     val ingestFlowArchivedDeposits = configuration.ingestFlowInboxArchived.map(collectDataFromDepositsDir(_, depositor, datamanager, age, "INGEST_FLOW_ARCHIVED")).getOrElse(Seq.empty)
@@ -342,7 +342,7 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
     "End of error report."
   }
 
-  def createErrorReport2(depositor: Option[DepositorId], datamanager: Option[Datamanager], age: Option[Age]): Try[String] = {
+  def createErrorReport(depositor: Option[DepositorId], datamanager: Option[Datamanager], age: Option[Age]): Try[String] = {
     import State._
     val errorFilter = (di: DepositInformation) => di match {
       case DepositInformation(_, _, _, _, _, INVALID, "abandoned draft, data removed", _, _, _, _, _, _, _, _, _) => false // see `clean-deposits.sh` (clean DRAFT section)

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
@@ -41,12 +41,12 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
     .doIfFailure { case e: Throwable =>  throw new IllegalStateException("Cannot connect to database", e) }
   private val propsTable = new DepositPropertiesTable(database)
 
-  def saveDepositProperties(uuid: String, props: PropertiesConfiguration): Try[Unit] = {
-    trace(uuid, props)
-    propsTable.save(uuid, props)
+  def saveDepositProperties(uuid: String, props: PropertiesConfiguration, propsText: String): Try[Unit] = {
+    trace(uuid, props, propsText)
+    propsTable.save(uuid, props, propsText)
   }
 
-  def getDepositProperties(uuid: String): Try[Option[PropertiesConfiguration]] = {
+  def getDepositProperties(uuid: String): Try[Option[String]] = {
     trace(uuid)
     propsTable.get(uuid)
   }

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
@@ -60,7 +60,7 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
     if (Files.exists(propsFile)) {
       val propsString = FileUtils.readFileToString(propsFile.toFile, StandardCharsets.UTF_8)
       readDepositProperties(propsString)
-        .map(p => saveDepositProperties(uuid, p, propsString))
+        .flatMap(p => saveDepositProperties(uuid, p, propsString))
         .map(_ => s"Saved deposit.properties for deposit $uuid")
         .unsafeGetOrThrow
     }
@@ -74,8 +74,8 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
     new PropertiesConfiguration() {
       setDelimiterParsingDisabled(true)
       load(new StringReader(s))
-      checkMandatoryKey(this, "status.label")
-      checkMandatoryKey(this, "status.description")
+      checkMandatoryKey(this, "state.label")
+      checkMandatoryKey(this, "state.description")
       checkMandatoryKey(this, "depositor.userId")
     }
   }

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
@@ -15,11 +15,13 @@
  */
 package nl.knaw.dans.easy.managedeposit
 
+import scala.math.Ordering.{ Long => LongComparator }
 import nl.knaw.dans.easy.managedeposit.Command.FeedBackMessage
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.apache.commons.io.FileUtils
+import org.joda.time.{ DateTime, DateTimeZone }
 import resource.managed
 
 import java.io.StringReader
@@ -136,6 +138,16 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
       throw new IllegalArgumentException(s"No such deposit $dir")
     }
   }
+
+  private def getLastModifiedStamp(path: Path): Option[DateTime] = {
+    managed(Files.list(path)).acquireAndGet {
+      _.map[Long](Files.getLastModifiedTime(_).toInstant.toEpochMilli)
+        .max(LongComparator)
+        .map[DateTime](new DateTime(_, DateTimeZone.UTC))
+        .toOption
+    }
+  }
+
 
   private def getLocationFromPath(path: Path): Option[String] = {
     val ap = path.toAbsolutePath

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
@@ -264,12 +264,13 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
   }
 
   def summary2(depositor: Option[DepositorId], datamanager: Option[Datamanager], age: Option[Age]): Try[String] = Try {
-    outputSummary()(Console.out)
+    outputSummary(depositor, datamanager, age)(Console.out)
     "End of summary report."
   }
 
-  def outputSummary(depositor: Option[DepositorId] = None)(implicit printStream: PrintStream): Try[Unit] = {
-    propsTable.getDepositSizeAndSpaceGroupedByState.map {
+  def outputSummary(depositor: Option[DepositorId] = None, datamanager: Option[Datamanager] = None, age: Option[Age] = None)(implicit printStream: PrintStream): Try[Unit] = {
+    trace(depositor, datamanager, age)
+    propsTable.getDepositSizeAndSpaceGroupedByState(depositor, datamanager, age).map {
       depositsGroupedByState =>
 
         val now = Calendar.getInstance().getTime

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
@@ -267,7 +267,7 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
   }
 
   def createFullReport2(depositor: Option[DepositorId], datamanager: Option[Datamanager], age: Option[Age]): Try[String] = {
-    managed(new ReportWriter(Console.out)).map(propsTable.processDepositInformation).map(_ => "End of full report.").tried
+    managed(new ReportWriter(Console.out)).map(propsTable.processDepositInformation()).map(_ => "End of full report.").tried
   }
 
   def createErrorReport(depositor: Option[DepositorId], datamanager: Option[Datamanager], age: Option[Age]): Try[String] = Try {
@@ -277,6 +277,12 @@ class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLo
     ReportGenerator.outputErrorReport(sword2Deposits ++ ingestFlowDeposits ++ ingestFlowArchivedDeposits)(Console.out)
     "End of error report."
   }
+
+  def createErrorReport2(depositor: Option[DepositorId], datamanager: Option[Datamanager], age: Option[Age]): Try[String] = {
+    import State._
+    managed(new ReportWriter(Console.out)).map(propsTable.processDepositInformation(List(INVALID, REJECTED, FAILED, UNKNOWN))).map(_ => "End of error report.").tried
+  }
+
 
   def createRawReport(location: Path): Try[String] = Try {
     ReportGenerator.outputRawReport(collectRawDepositProperties(location))(Console.out)

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositApp.scala
@@ -20,6 +20,7 @@ import nl.knaw.dans.easy.managedeposit.Command.FeedBackMessage
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import nl.knaw.dans.lib.string._
+import org.apache.commons.configuration.PropertiesConfiguration
 
 import java.net.{ URI, URL }
 import java.nio.file.{ Files, Path, Paths }
@@ -27,7 +28,7 @@ import scala.collection.JavaConverters._
 import scala.language.postfixOps
 import scala.util.{ Failure, Success, Try }
 
-class EasyManageDepositApp(configuration: Configuration2) extends DebugEnhancedLogging with Curation {
+class EasyManageDepositApp(configuration: Configuration) extends DebugEnhancedLogging with Curation {
   override val fedora: Fedora = configuration.fedora
   override val landingPageBaseUrl: URI = configuration.landingPageBaseUrl
 
@@ -36,9 +37,24 @@ class EasyManageDepositApp(configuration: Configuration2) extends DebugEnhancedL
     user = configuration.databaseUser,
     password = configuration.databasePassword,
     driver = configuration.databaseDriver)
-
+  logger.info("Initializing database connection...")
+  database.initConnectionPool()
+  logger.info("Database connection initialized.")
 
   private implicit val dansDoiPrefixes: List[String] = configuration.dansDoiPrefixes
+
+  def saveDepositProperties(uuid: String, props: PropertiesConfiguration): Try[Unit] = {
+
+    ???
+  }
+
+
+
+
+  def loadDepositProperties(uuid: String): Try[PropertiesConfiguration] = {
+
+    ???
+  }
 
   private def collectDataFromDepositsDir(depositsDir: Path, filterOnDepositor: Option[DepositorId], filterOnDatamanager: Option[Datamanager], filterOnAge: Option[Age], location: String): Deposits = {
     depositsDir.list(collectDataFromDepositsDir(filterOnDepositor, filterOnDatamanager, filterOnAge, location))

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositService.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositService.scala
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.managedeposit
+
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.servlet.ServletContextHandler
+import org.scalatra.{ LifeCycle, ScalatraServlet }
+import org.scalatra.servlet.ScalatraListener
+
+import javax.servlet.ServletContext
+import scala.util.Try
+
+class EasyManageDepositService(serverPort: Int,
+                               servlets: Map[String, ScalatraServlet]) extends DebugEnhancedLogging {
+
+  private val server = new Server(serverPort) {
+    setHandler(
+      new ServletContextHandler(ServletContextHandler.NO_SESSIONS) {
+        addEventListener(
+          new ScalatraListener() {
+            override def probeForCycleClass(classLoader: ClassLoader): (String, LifeCycle) = {
+              ("anonymous", new LifeCycle {
+                override def init(context: ServletContext): Unit = {
+                  for ((path, servlet) <- servlets)
+                    context.mount(servlet, path)
+                }
+              })
+            }
+          }
+        )
+      }
+    )
+  }
+  logger.info(s"HTTP port is $serverPort")
+
+  def start(): Try[Unit] = Try {
+    logger.info("Starting service...")
+    server.start()
+  }
+
+  def stop(): Try[Unit] = Try {
+    logger.info("Stopping service...")
+    server.stop()
+  }
+
+  def destroy(): Try[Unit] = Try {
+    server.destroy()
+    logger.info("Destroyed service.")
+  }
+}

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositServlet.scala
@@ -37,7 +37,7 @@ class EasyManageDepositServlet(app: EasyManageDepositApp,
       uuid = params("uuid")
       _ = debug(s"Found parameter uuid = $uuid")
       // TODO: check UUID is valid UUID
-      _ <- app.saveDepositProperties(uuid, props)
+      _ <- app.saveDepositProperties(uuid, props, request.body)
     } yield ()
 
     result match {
@@ -49,11 +49,13 @@ class EasyManageDepositServlet(app: EasyManageDepositApp,
   }
 
   get("/deposits/:uuid") {
-//    contentType = "text/plain"
-//    app.getDepositProperties(params("uuid")) match {
-//      case Success(Some(props))
-//
-//    }
+    contentType = "text/plain"
+    val uuid = params("uuid")
+    app.getDepositProperties(uuid) match {
+      case Success(Some(propsText)) => Ok(propsText)
+      case Success(None) => NotFound(s"No deposit.properties found for uuid = $uuid")
+      case Failure(NonFatal(e)) => InternalServerError(e.getMessage)
+    }
   }
 
   private def checkContentType(expected: String): Try[Unit] = {

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositServlet.scala
@@ -28,4 +28,6 @@ class EasyManageDepositServlet(app: EasyManageDepositApp,
   }
 
 
+
+
 }

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositServlet.scala
@@ -16,8 +16,11 @@
 package nl.knaw.dans.easy.managedeposit
 
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import org.apache.commons.configuration.PropertiesConfiguration
 import org.scalatra.{ Ok, ScalatraServlet }
 
+import java.io.StringReader
+import scala.util.Try
 import scala.util.control.NonFatal
 
 class EasyManageDepositServlet(app: EasyManageDepositApp,
@@ -27,7 +30,27 @@ class EasyManageDepositServlet(app: EasyManageDepositApp,
     Ok(s"EASY Manage Deposit running ($version)")
   }
 
+  put("deposits/:uuid") {
+    for {
+      props <- readDepositProperties(request.body)
+      uuid = params("uuid")
+      // TODO: check UUID is valid UUID
+
+    } yield ()
+    Ok()
+  }
+
+  get("deposits/:uuid") {
 
 
+  }
 
+  private def readDepositProperties(s: String): Try[PropertiesConfiguration] = Try {
+    new PropertiesConfiguration() {
+      setDelimiterParsingDisabled(true)
+      load(new StringReader(s))
+      //containsKey()
+      //TODO: check if minimally required keys are present
+    }
+  }
 }

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositServlet.scala
@@ -18,6 +18,7 @@ package nl.knaw.dans.easy.managedeposit
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.scalatra._
 
+import java.lang.IllegalArgumentException
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 
@@ -32,7 +33,11 @@ class EasyManageDepositServlet(app: EasyManageDepositApp,
     val uuid = params("uuid")
     app.loadSingleDepositProperties(uuid) match {
       case Success(_) => Ok()
-      case Failure(NonFatal(e)) => InternalServerError(e.getMessage)
+      case Failure(e: IllegalArgumentException) if e.getMessage.startsWith("No such deposit") => NotFound(s"Could not find deposit $uuid in deposit area")
+      case Failure(NonFatal(e)) => {
+        logger.error("Error loading deposit properties", e)
+        InternalServerError(e.getMessage)
+      }
     }
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositServlet.scala
@@ -16,10 +16,8 @@
 package nl.knaw.dans.easy.managedeposit
 
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-import org.apache.commons.configuration.PropertiesConfiguration
 import org.scalatra._
 
-import java.io.StringReader
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 
@@ -33,7 +31,7 @@ class EasyManageDepositServlet(app: EasyManageDepositApp,
   put("/deposits/:uuid") {
     val result = for {
       _ <- checkContentType("text/plain")
-      props <- readDepositProperties(request.body)
+      props <- app.readDepositProperties(request.body)
       uuid = params("uuid")
       _ = debug(s"Found parameter uuid = $uuid")
       // TODO: check UUID is valid UUID
@@ -61,20 +59,5 @@ class EasyManageDepositServlet(app: EasyManageDepositApp,
   private def checkContentType(expected: String): Try[Unit] = {
     if (request.contentType.contains(expected)) Success(())
     else Failure(new IllegalArgumentException(s"Media type must be '$expected', found '${ request.contentType.getOrElse("nothing") }'"))
-  }
-
-  private def readDepositProperties(s: String): Try[PropertiesConfiguration] = Try {
-    trace(s)
-    new PropertiesConfiguration() {
-      setDelimiterParsingDisabled(true)
-      load(new StringReader(s))
-      checkMandatoryKey(this, "status.label")
-      checkMandatoryKey(this, "status.description")
-      checkMandatoryKey(this, "depositor.userId")
-    }
-  }
-
-  private def checkMandatoryKey(props: PropertiesConfiguration, key: String): Unit = {
-    if (!props.containsKey(key)) throw new IllegalArgumentException(s"Missing mandatory key: '$key'")
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositServlet.scala
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.managedeposit
+
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import org.scalatra.{ Ok, ScalatraServlet }
+
+import scala.util.control.NonFatal
+
+class EasyManageDepositServlet(app: EasyManageDepositApp,
+                               version: String) extends ScalatraServlet with DebugEnhancedLogging {
+  get("/") {
+    contentType = "text/plain"
+    Ok(s"EASY Manage Deposit running ($version)")
+  }
+
+
+}

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositServlet.scala
@@ -28,22 +28,13 @@ class EasyManageDepositServlet(app: EasyManageDepositApp,
     Ok(s"EASY Manage Deposit running ($version)")
   }
 
-//  post("/deposits/:uuid/load") {
-//    val result = for {
-//      props <- app.loadSingleDepositProperties()
-//      uuid = params("uuid")
-//      _ = debug(s"Found parameter uuid = $uuid")
-//      // TODO: check UUID is valid UUID
-//      _ <- app.saveDepositProperties(uuid, props, request.body)
-//    } yield ()
-//
-//    result match {
-//      case Success(_) => Ok()
-//      case Failure(e: IllegalArgumentException) if e.getMessage.startsWith("Media type") => UnsupportedMediaType(e.getMessage)
-//      case Failure(e: IllegalArgumentException) => BadRequest(e.getMessage)
-//      case Failure(NonFatal(e)) => InternalServerError(e.getMessage)
-//    }
-//  }
+  post("/deposits/:uuid/load") {
+    val uuid = params("uuid")
+    app.loadSingleDepositProperties(uuid) match {
+      case Success(_) => Ok()
+      case Failure(NonFatal(e)) => InternalServerError(e.getMessage)
+    }
+  }
 
   get("/deposits/:uuid") {
     contentType = "text/plain"
@@ -53,10 +44,5 @@ class EasyManageDepositServlet(app: EasyManageDepositApp,
       case Success(None) => NotFound(s"No deposit.properties found for uuid = $uuid")
       case Failure(NonFatal(e)) => InternalServerError(e.getMessage)
     }
-  }
-
-  private def checkContentType(expected: String): Try[Unit] = {
-    if (request.contentType.contains(expected)) Success(())
-    else Failure(new IllegalArgumentException(s"Media type must be '$expected', found '${ request.contentType.getOrElse("nothing") }'"))
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositServlet.scala
@@ -28,23 +28,22 @@ class EasyManageDepositServlet(app: EasyManageDepositApp,
     Ok(s"EASY Manage Deposit running ($version)")
   }
 
-  put("/deposits/:uuid") {
-    val result = for {
-      _ <- checkContentType("text/plain")
-      props <- app.readDepositProperties(request.body)
-      uuid = params("uuid")
-      _ = debug(s"Found parameter uuid = $uuid")
-      // TODO: check UUID is valid UUID
-      _ <- app.saveDepositProperties(uuid, props, request.body)
-    } yield ()
-
-    result match {
-      case Success(_) => Ok()
-      case Failure(e: IllegalArgumentException) if e.getMessage.startsWith("Media type") => UnsupportedMediaType(e.getMessage)
-      case Failure(e: IllegalArgumentException) => BadRequest(e.getMessage)
-      case Failure(NonFatal(e)) => InternalServerError(e.getMessage)
-    }
-  }
+//  post("/deposits/:uuid/load") {
+//    val result = for {
+//      props <- app.loadSingleDepositProperties()
+//      uuid = params("uuid")
+//      _ = debug(s"Found parameter uuid = $uuid")
+//      // TODO: check UUID is valid UUID
+//      _ <- app.saveDepositProperties(uuid, props, request.body)
+//    } yield ()
+//
+//    result match {
+//      case Success(_) => Ok()
+//      case Failure(e: IllegalArgumentException) if e.getMessage.startsWith("Media type") => UnsupportedMediaType(e.getMessage)
+//      case Failure(e: IllegalArgumentException) => BadRequest(e.getMessage)
+//      case Failure(NonFatal(e)) => InternalServerError(e.getMessage)
+//    }
+//  }
 
   get("/deposits/:uuid") {
     contentType = "text/plain"

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/ReportGenerator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/ReportGenerator.scala
@@ -43,15 +43,15 @@ object ReportGenerator {
 
   def outputErrorReport(deposits: Deposits)(implicit printStream: PrintStream): Unit = {
     printRecords(deposits.filter {
-      case DepositInformation(_, _, _, _, _, INVALID, "abandoned draft, data removed", _, _, _, _, _, _, _, _) => false // see `clean-deposits.sh` (clean DRAFT section)
-      case DepositInformation(_, _, _, _, _, INVALID, _, _, _, _, _, _, _, _, _) => true
-      case DepositInformation(_, _, _, _, _, FAILED, _, _, _, _, _, _, _, _, _) => true
-      case DepositInformation(_, _, _, _, _, REJECTED, `requestChangesDescription`, _, _, _, _, "API", _, _, _) => false
-      case DepositInformation(_, _, _, _, _, REJECTED, _, _, _, _, _, _, _, _, _) => true
-      case DepositInformation(_, _, _, _, _, UNKNOWN, _, _, _, _, _, _, _, _, _) => true
-      case DepositInformation(_, _, _, _, _, null, _, _, _, _, _, _, _, _, _) => true
+      case DepositInformation(_, _, _, _, _, INVALID, "abandoned draft, data removed", _, _, _, _, _, _, _, _, _) => false // see `clean-deposits.sh` (clean DRAFT section)
+      case DepositInformation(_, _, _, _, _, INVALID, _, _, _, _, _, _, _, _, _, _) => true
+      case DepositInformation(_, _, _, _, _, FAILED, _, _, _, _, _, _, _, _, _, _) => true
+      case DepositInformation(_, _, _, _, _, REJECTED, `requestChangesDescription`, _, _, _, _, "API", _, _, _, _) => false
+      case DepositInformation(_, _, _, _, _, REJECTED, _, _, _, _, _, _, _, _, _, _) => true
+      case DepositInformation(_, _, _, _, _, UNKNOWN, _, _, _, _, _, _, _, _, _, _) => true
+      case DepositInformation(_, _, _, _, _, null, _, _, _, _, _, _, _, _, _, _) => true
       // When the doi of an archived deposit is NOT registered, an error should be raised
-      case d @ DepositInformation(_, _, Some(false), _, _, ARCHIVED, _, _, _, _, _, _, _, _, _) if d.isDansDoi => true
+      case d @ DepositInformation(_, _, Some(false), _, _, ARCHIVED, _, _, _, _, _, _, _, _, _, _) if d.isDansDoi => true
       case _ => false
     })
   }

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/ReportWriter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/ReportWriter.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.managedeposit
 
 import org.apache.commons.csv.CSVFormat
+import org.apache.commons.lang.StringUtils
 
 import java.io.PrintStream
 
@@ -41,7 +42,7 @@ class ReportWriter(printStream: PrintStream) extends Function[DepositInformation
       di.datamanager,
       di.creationTimestamp,
       di.lastModified,
-      di.description,
+      StringUtils.abbreviate(di.description, 1000),
       di.numberOfContinuedDeposits.toString,
       di.storageSpace.toString)
   }

--- a/src/main/scala/nl.knaw.dans.easy.managedeposit/ReportWriter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.managedeposit/ReportWriter.scala
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.managedeposit
+
+import org.apache.commons.csv.CSVFormat
+
+import java.io.PrintStream
+
+class ReportWriter(printStream: PrintStream) extends Function[DepositInformation, Unit] with AutoCloseable {
+  private val csvFormat: CSVFormat = CSVFormat.RFC4180
+    .withHeader("DEPOSITOR", "DEPOSIT_ID", "BAG_NAME", "DEPOSIT_STATE", "ORIGIN", "LOCATION", "DOI", "DOI_REGISTERED", "FEDORA_ID", "DATAMANAGER", "DEPOSIT_CREATION_TIMESTAMP",
+      "DEPOSIT_UPDATE_TIMESTAMP", "DESCRIPTION", "NBR_OF_CONTINUED_DEPOSITS", "STORAGE_IN_BYTES")
+    .withDelimiter(',')
+    .withRecordSeparator('\n')
+  private val printer = csvFormat.print(printStream)
+
+  override def apply(di: DepositInformation): Unit = {
+    printer.printRecord(
+      di.depositor,
+      di.depositId,
+      di.bagDirName,
+      di.state,
+      di.origin,
+      di.location,
+      di.doiIdentifier,
+      di.registeredString,
+      di.fedoraIdentifier,
+      di.datamanager,
+      di.creationTimestamp,
+      di.lastModified,
+      di.description,
+      di.numberOfContinuedDeposits.toString,
+      di.storageSpace.toString)
+  }
+
+  override def close(): Unit = {
+    printer.close()
+  }
+}

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -1,3 +1,5 @@
+daemon.http.port=20240
+
 easy-ingest-flow-inbox=./data/easy-ingest-flow-inbox
 easy-ingest-flow-inbox-archived=/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox-archived
 easy-sword2=./data/easy-sword2

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -1,5 +1,10 @@
 daemon.http.port=20240
 
+database.driver=org.postgresql.Driver
+database.url=jdbc:postgresql://localhost:5432/dd_migration_info
+database.user=dd_migration_info
+database.password=changeme
+
 easy-ingest-flow-inbox=./data/easy-ingest-flow-inbox
 easy-ingest-flow-inbox-archived=/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox-archived
 easy-sword2=./data/easy-sword2

--- a/src/test/scala/nl.knaw.dans.easy.managedeposit/DepositManagerSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.managedeposit/DepositManagerSpec.scala
@@ -27,10 +27,8 @@ import scala.util.{ Failure, Success }
 
 class DepositManagerSpec extends TestSupportFixture with BeforeAndAfterEach {
 
-  private val configuration = Configuration("1.0.0", createProperties())
-  private implicit val dansDoiPrefixes: List[String] = configuration.properties.getList("dans-doi.prefixes")
-    .asScala.toList
-    .map(prefix => prefix.asInstanceOf[String])
+  private val configuration = DummyConfiguration
+  private implicit val dansDoiPrefixes: List[String] = configuration.dansDoiPrefixes
 
   private val depositDirWithoutProperties = depositDir / "deposit-no-properties"
   private val depositDirWithoutPropertiesPath = depositDirWithoutProperties.path

--- a/src/test/scala/nl.knaw.dans.easy.managedeposit/DummyConfiguration.scala
+++ b/src/test/scala/nl.knaw.dans.easy.managedeposit/DummyConfiguration.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.easy.managedeposit
 
-object DummyConfiguration extends Configuration2(
+object DummyConfiguration extends Configuration(
   version = "0.0.0",
   serverPort = 20240,
   databaseUrl = null,

--- a/src/test/scala/nl.knaw.dans.easy.managedeposit/DummyConfiguration.scala
+++ b/src/test/scala/nl.knaw.dans.easy.managedeposit/DummyConfiguration.scala
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.managedeposit
+
+object DummyConfiguration extends Configuration2(
+  version = "0.0.0",
+  serverPort = 20240,
+  databaseUrl = null,
+  databaseUser = "",
+  databasePassword = "",
+  databaseDriver = "",
+  fedora = null,
+  sword2DepositsDir = null,
+  ingestFlowInbox = null,
+  ingestFlowInboxArchived = None,
+  landingPageBaseUrl = null,
+  dansDoiPrefixes = List.empty[String]
+)
+

--- a/src/test/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositSpec.scala
@@ -21,11 +21,13 @@ import org.apache.commons.configuration.PropertiesConfiguration
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.Inside.inside
 
+import java.net.URI
+import java.nio.file.Path
 import scala.util.Success
 
 class EasyManageDepositSpec extends TestSupportFixture with BeforeAndAfterEach {
 
-  private val app = new EasyManageDepositApp(Configuration("1.0.0", createProperties()))
+  private val app = new EasyManageDepositApp(createDummyConfiguration())
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -58,6 +60,24 @@ class EasyManageDepositSpec extends TestSupportFixture with BeforeAndAfterEach {
         n should have size 0
     }
   }
+
+  private def createDummyConfiguration(): Configuration2 = {
+    Configuration2(
+      version = "0.0.0",
+      serverPort = 20240,
+      databaseUrl = null,
+      databaseUser = "",
+      databasePassword = "",
+      databaseDriver = "",
+      fedora = null,
+      sword2DepositsDir = null,
+      ingestFlowInbox = null,
+      ingestFlowInboxArchived = None,
+      landingPageBaseUrl = null,
+      dansDoiPrefixes = List.empty[String]
+    )
+  }
+
 
   private def createProperties(): PropertiesConfiguration = {
     val properties = new PropertiesConfiguration()

--- a/src/test/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.managedeposit/EasyManageDepositSpec.scala
@@ -27,7 +27,7 @@ import scala.util.Success
 
 class EasyManageDepositSpec extends TestSupportFixture with BeforeAndAfterEach {
 
-  private val app = new EasyManageDepositApp(createDummyConfiguration())
+  private val app = new EasyManageDepositApp(DummyConfiguration)
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -59,35 +59,5 @@ class EasyManageDepositSpec extends TestSupportFixture with BeforeAndAfterEach {
       case Success(n) =>
         n should have size 0
     }
-  }
-
-  private def createDummyConfiguration(): Configuration2 = {
-    Configuration2(
-      version = "0.0.0",
-      serverPort = 20240,
-      databaseUrl = null,
-      databaseUser = "",
-      databasePassword = "",
-      databaseDriver = "",
-      fedora = null,
-      sword2DepositsDir = null,
-      ingestFlowInbox = null,
-      ingestFlowInboxArchived = None,
-      landingPageBaseUrl = null,
-      dansDoiPrefixes = List.empty[String]
-    )
-  }
-
-
-  private def createProperties(): PropertiesConfiguration = {
-    val properties = new PropertiesConfiguration()
-    properties.setProperty("easy-sword2", "")
-    properties.setProperty("easy-ingest-flow-inbox", "")
-    properties.setProperty("easy-ingest-flow-inbox-archived", "")
-    properties.setProperty("fedora.url", "http://something")
-    properties.setProperty("fedora.user", "")
-    properties.setProperty("fedora.password", "")
-    properties.setProperty("landing-pages.base-url", "")
-    properties
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.managedeposit/ReadmeSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.managedeposit/ReadmeSpec.scala
@@ -24,34 +24,34 @@ import java.nio.file.Paths
 
 class ReadmeSpec extends AnyFlatSpec with Matchers with CustomMatchers {
 
-//  private val clo = new CommandLineOptions(Array[String](), "1.0.0") {
-//    //avoids System.exit() in case of invalid arguments or "--help"
-//    override def verify(): Unit = {}
-//  }
-//
-//  private val helpInfo = {
-//    val mockedStdOut = new ByteArrayOutputStream()
-//    Console.withOut(mockedStdOut) {
-//      clo.printHelp()
-//    }
-//    mockedStdOut.toString
-//  }
-//
-//  private val readMe = File("docs/index.md")
-//
-//  "options in help info" should "be part of README.md" in {
-//    val lineSeparators = s"(${ System.lineSeparator() })+"
-//    val options = helpInfo.split(s"${ lineSeparators }Options:$lineSeparators")(1)
-//    options.trim.length shouldNot be(0)
-//    readMe should containTrimmed(options)
-//  }
-//
-//  "synopsis in help info" should "be part of README.md" in {
-//    readMe should containTrimmed(clo.synopsis)
-//  }
-//
-//  "description line(s) in help info" should "be part of README.md and pom.xml" in {
-//    readMe should containTrimmed(clo.description)
-//    File("pom.xml") should containTrimmed(clo.description)
-//  }
+  private val clo = new CommandLineOptions(Array[String](), "1.0.0") {
+    //avoids System.exit() in case of invalid arguments or "--help"
+    override def verify(): Unit = {}
+  }
+
+  private val helpInfo = {
+    val mockedStdOut = new ByteArrayOutputStream()
+    Console.withOut(mockedStdOut) {
+      clo.printHelp()
+    }
+    mockedStdOut.toString
+  }
+
+  private val readMe = File("docs/index.md")
+
+  "options in help info" should "be part of README.md" in {
+    val lineSeparators = s"(${ System.lineSeparator() })+"
+    val options = helpInfo.split(s"${ lineSeparators }Options:$lineSeparators")(1)
+    options.trim.length shouldNot be(0)
+    readMe should containTrimmed(options)
+  }
+
+  "synopsis in help info" should "be part of README.md" in {
+    readMe should containTrimmed(clo.synopsis)
+  }
+
+  "description line(s) in help info" should "be part of README.md and pom.xml" in {
+    readMe should containTrimmed(clo.description)
+    File("pom.xml") should containTrimmed(clo.description)
+  }
 }

--- a/src/test/scala/nl.knaw.dans.easy.managedeposit/ReadmeSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.managedeposit/ReadmeSpec.scala
@@ -24,7 +24,7 @@ import java.nio.file.Paths
 
 class ReadmeSpec extends AnyFlatSpec with Matchers with CustomMatchers {
 
-  private val clo = new CommandLineOptions(Array[String](), Configuration(Paths.get("src/main/assembly/dist"))) {
+  private val clo = new CommandLineOptions(Array[String](), "1.0.0") {
     //avoids System.exit() in case of invalid arguments or "--help"
     override def verify(): Unit = {}
   }

--- a/src/test/scala/nl.knaw.dans.easy.managedeposit/ReadmeSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.managedeposit/ReadmeSpec.scala
@@ -24,34 +24,34 @@ import java.nio.file.Paths
 
 class ReadmeSpec extends AnyFlatSpec with Matchers with CustomMatchers {
 
-  private val clo = new CommandLineOptions(Array[String](), "1.0.0") {
-    //avoids System.exit() in case of invalid arguments or "--help"
-    override def verify(): Unit = {}
-  }
-
-  private val helpInfo = {
-    val mockedStdOut = new ByteArrayOutputStream()
-    Console.withOut(mockedStdOut) {
-      clo.printHelp()
-    }
-    mockedStdOut.toString
-  }
-
-  private val readMe = File("docs/index.md")
-
-  "options in help info" should "be part of README.md" in {
-    val lineSeparators = s"(${ System.lineSeparator() })+"
-    val options = helpInfo.split(s"${ lineSeparators }Options:$lineSeparators")(1)
-    options.trim.length shouldNot be(0)
-    readMe should containTrimmed(options)
-  }
-
-  "synopsis in help info" should "be part of README.md" in {
-    readMe should containTrimmed(clo.synopsis)
-  }
-
-  "description line(s) in help info" should "be part of README.md and pom.xml" in {
-    readMe should containTrimmed(clo.description)
-    File("pom.xml") should containTrimmed(clo.description)
-  }
+//  private val clo = new CommandLineOptions(Array[String](), "1.0.0") {
+//    //avoids System.exit() in case of invalid arguments or "--help"
+//    override def verify(): Unit = {}
+//  }
+//
+//  private val helpInfo = {
+//    val mockedStdOut = new ByteArrayOutputStream()
+//    Console.withOut(mockedStdOut) {
+//      clo.printHelp()
+//    }
+//    mockedStdOut.toString
+//  }
+//
+//  private val readMe = File("docs/index.md")
+//
+//  "options in help info" should "be part of README.md" in {
+//    val lineSeparators = s"(${ System.lineSeparator() })+"
+//    val options = helpInfo.split(s"${ lineSeparators }Options:$lineSeparators")(1)
+//    options.trim.length shouldNot be(0)
+//    readMe should containTrimmed(options)
+//  }
+//
+//  "synopsis in help info" should "be part of README.md" in {
+//    readMe should containTrimmed(clo.synopsis)
+//  }
+//
+//  "description line(s) in help info" should "be part of README.md and pom.xml" in {
+//    readMe should containTrimmed(clo.description)
+//    File("pom.xml") should containTrimmed(clo.description)
+//  }
 }


### PR DESCRIPTION
Fixes EASY-2833

# Description of changes
* Adds a one-table database to index the `deposit.properties` text + some properties as separate columns, for faster searching and reporting of totals.
* Adds a simple HTTP-service that lets you load properties into the database by UUID. This is to be used by `easy-sword2` and `easy-ingest-flow` later, to keep the database up-to-date.
* Retains the old reporting code for now, to allow for regression testing.
* The `clean` command still crawls the disk, but now also updates the database, after making changes. 
* Refactors the Configuration class to look more like the other modules.

# How to test
* Deploy on the server using the modified `easy-dtap` (see Related PRs)
* Copy some deposits to the various directories of the deposit area, if not already filled.
* `easy-manage-deposit load-properties` (fills the database)
* `easy-manage-deposit report summary` (`full`, `error`, etc, try the various options)

# Related PRs
* https://github.com/DANS-KNAW/easy-dtap/pull/504

# Notify
* @DANS-KNAW/dataversedans
* @DANS-KNAW/easy